### PR TITLE
fix: typo saying VAULTLS_API_SECRET is missing

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -450,7 +450,7 @@ async fn rocket() -> _ {
         },
         false => None
     };
-    let rocket_secret = env::var("VAULTLS_API_SECRET").expect("VAULTS_API_SECRET is not set");
+    let rocket_secret = env::var("VAULTLS_API_SECRET").expect("VAULTLS_API_SECRET is not set");
     unsafe { env::set_var("ROCKET_SECRET_KEY", rocket_secret) }
 
     let app_state = AppState {


### PR DESCRIPTION
Hey,

I just tried to deploy your project and I meet an issue telling the env var was missing, I copied the name from the log but this name was wrong 😬

I just fixed it

Thank for your work!