### PR TITLE
fix: make CAs `critical`, and include `AKI` and `SKI`

### DIFF
--- a/backend/src/certs/tls_cert.rs
+++ b/backend/src/certs/tls_cert.rs
@@ -168,7 +168,7 @@ impl TLSCertificateBuilder {
         let cn = create_cn(&name)?;
         self.x509.set_issuer_name(&cn)?;
 
-        let basic_constraints = BasicConstraints::new().ca().build()?;
+        let basic_constraints = BasicConstraints::new().critical().ca().build()?;
         self.x509.append_extension(basic_constraints)?;
 
         let key_usage = KeyUsage::new()

--- a/backend/src/certs/tls_cert.rs
+++ b/backend/src/certs/tls_cert.rs
@@ -232,6 +232,12 @@ impl TLSCertificateBuilder {
 
         self.x509.set_issuer_name(ca_cert.subject_name())?;
 
+        let subject_key_identifier = SubjectKeyIdentifier::new().build(&self.x509.x509v3_context(None, None))?;
+        self.x509.append_extension(subject_key_identifier)?;
+        
+        let authority_key_identifier = AuthorityKeyIdentifier::new().keyid(true).build(&self.x509.x509v3_context(Some(&ca_cert), None))?;
+        self.x509.append_extension(authority_key_identifier)?;
+
         self.x509.sign(&ca_key, MessageDigest::sha256())?;
         let cert = self.x509.build();
 


### PR DESCRIPTION
## Summary

I'm opening this PR to help users set up Authentik's mTLS Authentication.
For it to succeed, VaulTLS must comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280).

In this case, it doesn't comply with the following points:
* CA not marked as `critical`.
* Leaf certificates don't include the AKI nor the SKI.

## Documentation

* As per [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280),
  * [4.2.1.9](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9).  Basic Constraints: 
     ```
     Conforming CAs MUST include this extension in all CA certificates that contain public keys used to validate digital signatures on certificates and MUST mark the extension as critical in such certificates.
     ```
  * [4.2.1.2](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2).  Subject Key Identifier: 
     ```
     To assist applications in identifying the appropriate end entity certificate, this extension SHOULD be included in all end entity certificates.
     ```
  * [4.2.1.1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1).  Authority Key Identifier: 
     ```
     The keyIdentifier field of the authorityKeyIdentifier extension MUST be included in all certificates generated by conforming CAs to facilitate certification path construction.  There is one exception; where a CA distributes its public key in the form of a "self-signed" certificate, the authority key identifier MAY be omitted.
     ```