### PR TITLE
backend: update hickory-resolver

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -455,6 +455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +511,16 @@ dependencies = [
  "subtle",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -921,18 +941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1105,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1136,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1308,24 +1328,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1336,22 +1355,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -1754,6 +1798,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1790,6 +1837,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2084,6 +2180,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -2583,6 +2685,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -3209,6 +3322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3308,7 +3430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3541,6 +3663,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +3883,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4241,6 +4400,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,6 +4569,15 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -52,7 +52,7 @@ rand = "0.10.1"
 zip = "8.5.1"
 rand_core = "0.10.1"
 reqwest = { version = "0.12", default-features = false, features = ["http2", "rustls-tls"] }
-hickory-resolver = { version = "0.25", features = ["tokio", "system-config", "tls-ring"] }
+hickory-resolver = { version = "0.26.1", features = ["tokio", "system-config", "tls-ring"] }
 rcgen = { version = "0.14.7", features = ["pem", "x509-parser", "crypto", "aws_lc_rs"] }
 rustls-pki-types = "1.14.0"
 time = "0.3.47"

--- a/backend/src/acme/routes.rs
+++ b/backend/src/acme/routes.rs
@@ -1,7 +1,12 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{DateTime, Utc};
+use hickory_resolver::config::ConnectionConfig;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::Record;
 use rand_core::Rng;
 use tracing::{error, info, warn};
 use rocket::{get, head, post, routes, State};
@@ -51,32 +56,27 @@ fn doh_client() -> &'static reqwest::Client {
 
 fn build_udp_resolver(addr: &str) -> Result<hickory_resolver::TokioResolver, String> {
     use hickory_resolver::config::{NameServerConfig, ResolverConfig};
-    use hickory_resolver::name_server::TokioConnectionProvider;
-    use hickory_resolver::proto::xfer::Protocol;
     use hickory_resolver::Resolver;
-    use std::net::{IpAddr, SocketAddr};
+    use std::net::IpAddr;
 
     if addr.is_empty() {
-        return hickory_resolver::TokioResolver::builder_tokio()
-            .map(|b| b.build())
-            .map_err(|e| format!("Failed to read system DNS config: {e}"));
+        return Ok(Resolver::builder_tokio().unwrap().build().unwrap());
     }
 
     let socket_addr: SocketAddr = addr.parse()
         .or_else(|_| addr.parse::<IpAddr>().map(|ip| SocketAddr::new(ip, 53)))
         .map_err(|_| format!("Invalid DNS resolver address: {addr}"))?;
-
-    let ns = NameServerConfig::new(socket_addr, Protocol::Udp);
+    let mut connection_config = ConnectionConfig::udp();
+    connection_config.port = socket_addr.port();
+    let ns = NameServerConfig::new(socket_addr.ip(), false, vec![connection_config]);
     let config = ResolverConfig::from_parts(None, vec![], vec![ns]);
-    Ok(Resolver::builder_with_config(config, TokioConnectionProvider::default()).build())
+    Ok(Resolver::builder_with_config(config, TokioRuntimeProvider::default()).build().unwrap())
 }
 
 fn build_dot_resolver(addr: &str) -> Result<hickory_resolver::TokioResolver, String> {
     use hickory_resolver::config::{NameServerConfig, ResolverConfig};
-    use hickory_resolver::name_server::TokioConnectionProvider;
-    use hickory_resolver::proto::xfer::Protocol;
     use hickory_resolver::Resolver;
-    use std::net::{IpAddr, SocketAddr};
+    use std::net::IpAddr;
 
     let (addr_part, tls_name_opt) = match addr.find('#') {
         Some(idx) => (&addr[..idx], Some(addr[idx + 1..].to_string())),
@@ -95,17 +95,16 @@ fn build_dot_resolver(addr: &str) -> Result<hickory_resolver::TokioResolver, Str
 
     let ip: IpAddr = ip_str.parse()
         .map_err(|_| format!("Invalid DoT IP address: {ip_str}"))?;
-    let socket_addr = SocketAddr::new(ip, port);
     let tls_name = tls_name_opt.unwrap_or_else(|| ip_str.to_string());
-
-    let mut ns = NameServerConfig::new(socket_addr, Protocol::Tls);
-    ns.tls_dns_name = Some(tls_name);
+    let mut connection_config = ConnectionConfig::tls(Arc::from(tls_name));
+    connection_config.port = port;
+    let ns = NameServerConfig::new(ip, false, vec![connection_config]);
     let config = ResolverConfig::from_parts(None, vec![], vec![ns]);
-    Ok(Resolver::builder_with_config(config, TokioConnectionProvider::default()).build())
+    Ok(Resolver::builder_with_config(config, TokioRuntimeProvider::default()).build().unwrap())
 }
 
 async fn validate_dns01_doh(domain: &str, expected_value: &str, url: &str) -> bool {
-    use hickory_resolver::proto::op::{Message, MessageType, OpCode, Query};
+    use hickory_resolver::proto::op::{Message, Query};
     use hickory_resolver::proto::rr::{Name, RData, RecordType};
 
     let lookup_name = format!("_acme-challenge.{}.", domain);
@@ -121,11 +120,8 @@ async fn validate_dns01_doh(domain: &str, expected_value: &str, url: &str) -> bo
     query.set_name(name);
     query.set_query_type(RecordType::TXT);
 
-    let mut message = Message::new();
-    message.set_id(1);
-    message.set_message_type(MessageType::Query);
-    message.set_op_code(OpCode::Query);
-    message.set_recursion_desired(true);
+    let mut message = Message::query();
+    message.metadata.recursion_desired = true;
     message.add_query(query);
 
     let wire_bytes = match message.to_vec() {
@@ -172,11 +168,9 @@ async fn validate_dns01_doh(domain: &str, expected_value: &str, url: &str) -> bo
         }
     };
 
-    response.answers().iter().any(|record| {
-        if let RData::TXT(txt) = record.data() {
-            let record_text: String = txt.iter()
-                .map(|data| String::from_utf8_lossy(data).to_string())
-                .collect();
+    response.answers.iter().any(|record: &Record | {
+        if let RData::TXT(ref txt) = record.data {
+            let record_text: String = txt.to_string();
             record_text == expected_value
         } else {
             false
@@ -206,17 +200,13 @@ async fn validate_dns01(domain: &str, expected_value: &str, resolver_addr: &str)
     let lookup_name = format!("_acme-challenge.{domain}.");
     match resolver.txt_lookup(&lookup_name).await {
         Ok(records) => {
-            let matched = records.iter().any(|txt| {
-                let record_text: String = txt.iter()
-                    .map(|data| String::from_utf8_lossy(data).to_string())
-                    .collect();
+            let matched = records.answers().iter().any(|txt: &Record | {
+                let record_text: String = txt.data.to_string();
                 record_text == expected_value
             });
             if !matched {
-                let found: Vec<String> = records.iter().map(|txt| {
-                    txt.iter()
-                        .map(|data| String::from_utf8_lossy(data).to_string())
-                        .collect()
+                let found: Vec<String> = records.answers().iter().map(|txt: &Record | {
+                    txt.to_string()
                 }).collect();
                 error!(domain=domain, expected=expected_value, found=?found, "DNS-01 TXT value mismatch");
             }

--- a/backend/src/acme/routes.rs
+++ b/backend/src/acme/routes.rs
@@ -54,6 +54,29 @@ fn doh_client() -> &'static reqwest::Client {
     })
 }
 
+fn doh_client_insecure() -> &'static reqwest::Client {
+    DOH_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("Failed to build insecure DoH client")
+    })
+}
+
+fn doh_url_host_is_ip(url: &str) -> bool {
+    let without_scheme = url.strip_prefix("https://").unwrap_or(url);
+    let host_and_path = without_scheme.split('/').next().unwrap_or("");
+    let host = if host_and_path.starts_with('[') {
+        &host_and_path[..host_and_path.find(']').map(|i| i + 1).unwrap_or(host_and_path.len())]
+    } else {
+        host_and_path.split(':').next().unwrap_or(host_and_path)
+    };
+    host.trim_matches(|c| c == '[' || c == ']')
+        .parse::<std::net::IpAddr>()
+        .is_ok()
+}
+
 fn build_udp_resolver(addr: &str) -> Result<hickory_resolver::TokioResolver, String> {
     use hickory_resolver::config::{NameServerConfig, ResolverConfig};
     use hickory_resolver::Resolver;
@@ -75,7 +98,7 @@ fn build_udp_resolver(addr: &str) -> Result<hickory_resolver::TokioResolver, Str
 
 fn build_dot_resolver(addr: &str) -> Result<hickory_resolver::TokioResolver, String> {
     use hickory_resolver::config::{NameServerConfig, ResolverConfig};
-    use hickory_resolver::Resolver;
+    use hickory_resolver::{Resolver, TlsConfig};
     use std::net::IpAddr;
 
     let (addr_part, tls_name_opt) = match addr.find('#') {
@@ -95,12 +118,20 @@ fn build_dot_resolver(addr: &str) -> Result<hickory_resolver::TokioResolver, Str
 
     let ip: IpAddr = ip_str.parse()
         .map_err(|_| format!("Invalid DoT IP address: {ip_str}"))?;
+    let skip_verify = tls_name_opt.is_none();
     let tls_name = tls_name_opt.unwrap_or_else(|| ip_str.to_string());
     let mut connection_config = ConnectionConfig::tls(Arc::from(tls_name));
     connection_config.port = port;
     let ns = NameServerConfig::new(ip, false, vec![connection_config]);
     let config = ResolverConfig::from_parts(None, vec![], vec![ns]);
-    Ok(Resolver::builder_with_config(config, TokioRuntimeProvider::default()).build().unwrap())
+    let mut builder = Resolver::builder_with_config(config, TokioRuntimeProvider::default());
+    if skip_verify {
+        let mut tls_cfg = TlsConfig::new()
+            .map_err(|e| format!("Failed to create TLS config: {e}"))?;
+        tls_cfg.insecure_skip_verify();
+        builder = builder.with_tls_config(tls_cfg.config);
+    }
+    Ok(builder.build().unwrap())
 }
 
 async fn validate_dns01_doh(domain: &str, expected_value: &str, url: &str) -> bool {
@@ -132,7 +163,8 @@ async fn validate_dns01_doh(domain: &str, expected_value: &str, url: &str) -> bo
         }
     };
 
-    let resp = match doh_client()
+    let client = if doh_url_host_is_ip(url) { doh_client_insecure() } else { doh_client() };
+    let resp = match client
         .post(url)
         .header("Content-Type", "application/dns-message")
         .header("Accept", "application/dns-message")


### PR DESCRIPTION
hickory-resolver changed their API for the 0.26 release, requiring some refactoring.

Adjust dns resolver creation and doh validation