### PR TITLE
Add SSH Revocation functionality

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -10,7 +10,7 @@ use crate::auth::oidc_auth::OidcAuth;
 use crate::auth::password_auth::Password;
 use crate::auth::session_auth::{generate_token, invalidate_token, Authenticated, AuthenticatedPrivileged};
 use crate::certs::common::{get_password, save_ca, Certificate, CA};
-use crate::certs::ssh_cert::{get_ssh_pem, SSHCertificateBuilder};
+use crate::certs::ssh_cert::{create_and_save_krl, create_krl, get_ssh_pem, retrieve_krl, SSHCertificateBuilder};
 use crate::certs::tls_cert::{create_and_save_crl, create_crl, get_timestamp, get_tls_pem, retrieve_crl, save_crl, TLSCertificateBuilder};
 use crate::constants::VAULTLS_VERSION;
 use crate::data::api::{CallbackQuery, ChangePasswordRequest, CreateCARequest, CreateUserCertificateRequest, CreateUserRequest, DownloadResponse, IsSetupResponse, LoginRequest, SetupRequest};
@@ -663,13 +663,10 @@ pub(crate) async fn delete_user_cert(
     Ok(())
 }
 
-async fn create_crl_params(state: &State<AppState>, ca_id: i64) -> Result<(CA, Vec<(Vec<u8>, i64)>, i64), ApiError>{
-    let ca = state.db.get_ca_by_id(ca_id).await.map_err(|_| ApiError::NotFound(None))?;
-    if ca.ca_type != CAType::TLS {
-        return Err(ApiError::Other("CRL is only supported for TLS CAs".to_string()));
-    }
+async fn create_crl_params(state: &State<AppState>, ca: &CA) -> Result<(Vec<(Vec<u8>, i64)>, i64), ApiError>{
+    assert_eq!(ca.ca_type, CAType::TLS);
 
-    let revoked_certs = state.db.get_user_certs(None, Some(ca_id), Some(true)).await.map_err(|e| ApiError::Other(e.to_string()))?;
+    let revoked_certs = state.db.get_user_certs(None, Some(ca.id), Some(true)).await.map_err(|e| ApiError::Other(e.to_string()))?;
 
     let mut revoked_params = Vec::new();
     for cert in revoked_certs {
@@ -681,7 +678,21 @@ async fn create_crl_params(state: &State<AppState>, ca_id: i64) -> Result<(CA, V
 
     let crl_next_update_hours = state.settings.get_crl_next_update_hours();
 
-    Ok((ca, revoked_params, crl_next_update_hours))
+    Ok((revoked_params, crl_next_update_hours))
+}
+
+async fn create_krl_params(state: &State<AppState>, ca: &CA) -> Result<Vec<Vec<u8>>, ApiError> {
+    assert_eq!(ca.ca_type, CAType::SSH);
+
+    let revoked_certs = state.db.get_user_certs(None, Some(ca.id), Some(true)).await.map_err(|e| ApiError::Other(e.to_string()))?;
+
+    let mut revoked_serials = Vec::new();
+    for cert in revoked_certs {
+        let serial = cert.get_serial()?;
+        revoked_serials.push(serial);
+    }
+
+    Ok(revoked_serials)
 }
 
 #[openapi(tag = "Certificates")]
@@ -696,45 +707,74 @@ pub(crate) async fn revoke_certificate(
     if cert.user_id != authentication._claims.id && authentication._claims.role != UserRole::Admin { return Err(ApiError::Forbidden(None)) }
     state.db.revoke_user_cert(id).await.map_err(|e| ApiError::Other(e.to_string()))?;
 
-    let (mut ca, revoked_params, crl_next_update_hours) = create_crl_params(state, cert.ca_id).await?;
-    create_and_save_crl(&mut ca, revoked_params, crl_next_update_hours)?;
-    state.db.increase_ca_crl_number(ca.id, ca.crl_number).await?;
+    let mut ca = state.db.get_ca_by_id(cert.ca_id).await.map_err(|_| ApiError::NotFound(None))?;
+    match ca.ca_type {
+        CAType::TLS => {
+            let (revoked_params, crl_next_update_hours) = create_crl_params(state, &ca).await?;
+            create_and_save_crl(&mut ca, revoked_params, crl_next_update_hours)?;
+            state.db.increase_ca_crl_number(ca.id, ca.crl_number).await?;
+        }
+        CAType::SSH => {
+            let revoked_serials = create_krl_params(state, &ca).await?;
+            create_and_save_krl(&mut ca, &revoked_serials)?;
+            state.db.increase_ca_crl_number(ca.id, ca.crl_number).await?;
+        }
+    }
 
     Ok(())
 }
 
 #[openapi(tag = "Certificates")]
 #[get("/certificates/ca/<id>/crl?<format>")]
-/// Get the Certificate Revocation List (CRL) for a TLS CA.
+/// Get the Certificate Revocation List (CRL) for a TLS CA or Key Revocation List (KRL) for an SSH CA.
 pub(crate) async fn download_crl(
     state: &State<AppState>,
     id: i64,
     format: Option<DataFormat>
 ) -> Result<DownloadResponse, ApiError> {
-    let crl_der = match retrieve_crl(id) {
-        Ok(crl_der) => crl_der,
-        Err(_) => {
-            // Probably no CRLs revoked yet, need to create empty CRL
-            let (mut ca, revoked_params, crl_next_update_hours) = create_crl_params(state, id).await?;
-            let crl_der = create_crl(&mut ca, revoked_params, crl_next_update_hours)?;
-            state.db.increase_ca_crl_number(ca.id, ca.crl_number).await?;
-            let _ = save_crl(crl_der.clone(), id); // Ignore errors
-            crl_der
-        }
-    };
+    let mut ca = state.db.get_ca_by_id(id).await.map_err(|_| ApiError::NotFound(None))?;
+    match ca.ca_type {
+        CAType::TLS => {
+            let crl_der = match retrieve_crl(id) {
+                Ok(crl_der) => crl_der,
+                Err(_) => {
+                    // Probably no CRLs revoked yet, need to create empty CRL
+                    let (revoked_params, crl_next_update_hours) = create_crl_params(state, &ca).await?;
+                    let crl_der = create_crl(&mut ca, revoked_params, crl_next_update_hours)?;
+                    state.db.increase_ca_crl_number(ca.id, ca.crl_number).await?;
+                    let _ = save_crl(crl_der.clone(), id); // Ignore errors
+                    crl_der
+                }
+            };
 
-    let (crl_data, extension) = match format.unwrap_or_default() {
-        DataFormat::DER => (crl_der, "crl"),
-        DataFormat::PEM => {
-            let pem = openssl::x509::X509Crl::from_der(&crl_der)
-                .map_err(|e| ApiError::Other(e.to_string()))?
-                .to_pem()
-                .map_err(|e| ApiError::Other(e.to_string()))?;
-            (pem, "pem")
-        }
-    };
+            let (crl_data, extension) = match format.unwrap_or_default() {
+                DataFormat::DER => (crl_der, "crl"),
+                DataFormat::PEM => {
+                    let pem = openssl::x509::X509Crl::from_der(&crl_der)
+                        .map_err(|e| ApiError::Other(e.to_string()))?
+                        .to_pem()
+                        .map_err(|e| ApiError::Other(e.to_string()))?;
+                    (pem, "pem")
+                }
+            };
 
-    Ok(DownloadResponse::new(crl_data, &format!("crl-{}.{}", id, extension)))
+            Ok(DownloadResponse::new(crl_data, &format!("crl-{}.{}", id, extension)))
+        }
+        CAType::SSH => {
+            let krl_bytes = match retrieve_krl(id) {
+                Ok(krl_bytes) => krl_bytes,
+                Err(_) => {
+                    // Probably no certs revoked yet, need to create empty KRL
+                    let revoked_serials = create_krl_params(state, &ca).await?;
+                    let krl_bytes = create_krl(&mut ca, &revoked_serials)?;
+                    state.db.increase_ca_crl_number(ca.id, ca.crl_number).await?;
+                    let _ = crate::certs::ssh_cert::save_krl(krl_bytes.clone(), id);
+                    krl_bytes
+                }
+            };
+            Ok(DownloadResponse::new(krl_bytes, &format!("krl-{}.krl", id)))
+        }
+    }
 }
 
 #[openapi(tag = "Settings")]

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -673,7 +673,7 @@ async fn create_crl_params(state: &State<AppState>, ca_id: i64) -> Result<(CA, V
 
     let mut revoked_params = Vec::new();
     for cert in revoked_certs {
-        let serial = crate::certs::tls_cert::extract_serial_number(&cert)
+        let serial = cert.get_serial()
             .map_err(|_| ApiError::Other("Could not retrieve serial number from certificate to create CRL".to_string()))?;
 
         revoked_params.push((serial, cert.revoked_at.unwrap_or(0)));

--- a/backend/src/certs/common.rs
+++ b/backend/src/certs/common.rs
@@ -1,6 +1,9 @@
+use anyhow::Result;
 use rocket::serde::{Deserialize, Serialize};
 use rocket_okapi::JsonSchema;
 use passwords::PasswordGenerator;
+use crate::certs::ssh_cert::extract_ssh_serial_number;
+use crate::certs::tls_cert::{extract_pem_serial_number, extract_pkcs12_serial_number};
 use crate::data::enums::{CAType, CertData, CertificateRenewMethod, CertificateType};
 use crate::data::objects::Name;
 
@@ -47,6 +50,14 @@ impl Certificate {
             ca_id: row.get(9)?,
             revoked_at: row.get(10)?
         })
+    }
+
+    pub(crate) fn get_serial(&self) -> Result<Vec<u8>> {
+        match self.data {
+            CertData::Pkcs12(ref pkcs12) => { extract_pkcs12_serial_number(pkcs12, &self.password) }
+            CertData::Pem(ref pem) => { extract_pem_serial_number(pem) }
+            CertData::SshBundle(ref ssh) => { extract_ssh_serial_number(ssh, &self.name.to_string()) }
+        }
     }
 }
 

--- a/backend/src/certs/ssh_cert.rs
+++ b/backend/src/certs/ssh_cert.rs
@@ -12,6 +12,12 @@ use tracing::trace;
 use zip::write::SimpleFileOptions;
 use zip::ZipWriter;
 use crate::data::enums::CAType::SSH;
+#[cfg(not(feature = "test-mode"))]
+use crate::constants::{KRL_DIR_PATH, KRL_FILE_PATTERN};
+use std::fs;
+#[cfg(feature = "test-mode")]
+use std::env::temp_dir;
+use crate::data::error::ApiError;
 
 pub struct SSHCertificateBuilder {
     created_on: i64,
@@ -242,5 +248,99 @@ pub fn extract_ssh_serial_number(data: &Vec<u8>, name: &str) -> Result<Vec<u8>> 
     cert_file.read_to_end(&mut cert_bytes).map_err(|e: std::io::Error| ApiError::Other(e.to_string()))?;
     let cert_str = String::from_utf8_lossy(&cert_bytes);
     let ssh_cert = ssh_key::Certificate::from_openssh(&cert_str).map_err(|e| ApiError::Other(e.to_string()))?;
-    Ok((ssh_cert.serial() as u32).to_be_bytes().into())
+    Ok(ssh_cert.serial().to_be_bytes().into())
+}
+
+#[cfg(not(feature = "test-mode"))]
+pub(crate) fn retrieve_krl(ca_id: i64) -> Result<Vec<u8>> {
+    let ca_id_file_path = KRL_FILE_PATTERN.replace("{}", &ca_id.to_string());
+    Ok(fs::read(ca_id_file_path)?)
+}
+
+#[cfg(feature = "test-mode")]
+pub(crate) fn retrieve_krl(ca_id: i64) -> Result<Vec<u8>> {
+    let mut path = temp_dir();
+    path.push(format!("krl-{}.krl", ca_id));
+    Ok(fs::read(path)?)
+}
+
+pub(crate) fn create_and_save_krl(ca: &mut CA, revoked_serials: &Vec<Vec<u8>>) -> Result<()> {
+    let krl_bytes = create_krl(ca, revoked_serials)?;
+    save_krl(krl_bytes, ca.id)
+}
+
+pub(crate) fn create_krl(ca: &mut CA, revoked_serials: &Vec<Vec<u8>>) -> Result<Vec<u8>> {
+    let mut krl = Vec::new();
+
+    // --- KRL Header ---
+    krl.extend_from_slice(b"SSHKRL\n\0"); // Format Identifier
+    krl.extend_from_slice(&1u32.to_be_bytes()); // Format Version
+
+    // KRL Version
+    ca.crl_number += 1;
+    let krl_version = (ca.crl_number as u64).to_be_bytes();
+    krl.extend_from_slice(&krl_version);
+
+    // Date
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    krl.extend_from_slice(&now.to_be_bytes());
+
+    krl.extend_from_slice(&0u64.to_be_bytes()); // Flags
+    krl.extend_from_slice(&0u32.to_be_bytes()); // Reserved
+    krl.extend_from_slice(&0u32.to_be_bytes()); // Comment
+
+    // --- KRL Body ---
+    // Consists of one section
+    // Section consists of CA information and subsection with all revoked keys
+    krl.push(1 /* KRL_SECTION_CERTIFICATES */);
+
+    let mut section_data = Vec::new();
+
+    // Extract the CA pubkey blob from the CA private key bytes
+    let ca_private_key = PrivateKey::from_bytes(&ca.key)?;
+    let ca_pubkey_blob = ca_private_key.public_key().to_bytes()?;
+
+    // CA Key as String (Length + Bytes)
+    section_data.extend_from_slice(&(ca_pubkey_blob.len() as u32).to_be_bytes());
+    section_data.extend_from_slice(&ca_pubkey_blob);
+
+    // Reserved
+    section_data.extend_from_slice(&0u32.to_be_bytes());
+
+    // SUBSECTION: cert_section_type = 0x20 (KRL_SECTION_CERT_SERIAL_LIST)
+    section_data.push(0x20);
+
+    // SUBSECTION: cert_section_data
+    // OpenSSH expects pairs of (min, max) u64s.
+    // To revoke single serials, the min and max are identical.
+    let mut cert_section_data = Vec::new();
+    for serial in revoked_serials {
+        cert_section_data.extend_from_slice(serial);
+    }
+
+    // Write cert_section_data as an SSH string (length + data) into the section_data
+    section_data.extend_from_slice(&(cert_section_data.len() as u32).to_be_bytes());
+    section_data.extend_from_slice(&cert_section_data);
+
+    // Finally, write section_data as an SSH string into the main KRL buffer
+    krl.extend_from_slice(&(section_data.len() as u32).to_be_bytes());
+    krl.extend_from_slice(&section_data);
+
+    Ok(krl)
+}
+
+#[cfg(not(feature = "test-mode"))]
+pub(crate) fn save_krl(krl_bytes: Vec<u8>, ca_id: i64) -> Result<()> {
+    let ca_id_file_path = KRL_FILE_PATTERN.replace("{}", &ca_id.to_string());
+    fs::create_dir_all(KRL_DIR_PATH)?;
+    fs::write(ca_id_file_path, krl_bytes)?;
+    Ok(())
+}
+
+#[cfg(feature = "test-mode")]
+pub(crate) fn save_krl(krl_bytes: Vec<u8>, ca_id: i64) -> Result<()> {
+    let mut path = temp_dir();
+    path.push(format!("krl-{}.krl", ca_id));
+    fs::write(path, krl_bytes)?;
+    Ok(())
 }

--- a/backend/src/certs/ssh_cert.rs
+++ b/backend/src/certs/ssh_cert.rs
@@ -6,7 +6,7 @@ use rand::prelude::*;
 use rand::rng;
 use ssh_key::rand_core::OsRng;
 use ssh_key::{certificate, Algorithm, LineEnding, PrivateKey};
-use std::io::{Cursor, Write};
+use std::io::{Cursor, Read, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::trace;
 use zip::write::SimpleFileOptions;
@@ -232,4 +232,15 @@ pub fn get_ssh_pem(ca: &CA) -> Result<Vec<u8>> {
     let private_key = PrivateKey::from_bytes(&ca.key)?;
     let public_key = private_key.public_key();
     Ok(public_key.to_openssh()?.as_bytes().to_vec())
+}
+
+pub fn extract_ssh_serial_number(data: &Vec<u8>, name: &str) -> Result<Vec<u8>> {
+    let reader = Cursor::new(data);
+    let mut zip = zip::ZipArchive::new(reader).map_err(|e: zip::result::ZipError| ApiError::Other(e.to_string()))?;
+    let mut cert_file = zip.by_name(&format!("{}.pub", name)).map_err(|e: zip::result::ZipError| ApiError::Other(e.to_string()))?;
+    let mut cert_bytes = Vec::new();
+    cert_file.read_to_end(&mut cert_bytes).map_err(|e: std::io::Error| ApiError::Other(e.to_string()))?;
+    let cert_str = String::from_utf8_lossy(&cert_bytes);
+    let ssh_cert = ssh_key::Certificate::from_openssh(&cert_str).map_err(|e| ApiError::Other(e.to_string()))?;
+    Ok((ssh_cert.serial() as u32).to_be_bytes().into())
 }

--- a/backend/src/certs/tls_cert.rs
+++ b/backend/src/certs/tls_cert.rs
@@ -404,21 +404,17 @@ pub(crate) fn get_tls_pem(ca: &CA) -> Result<Vec<u8>, ErrorStack> {
     cert.to_pem()
 }
 
-pub fn extract_serial_number(cert: &Certificate) -> Result<Vec<u8>> {
-    match &cert.data {
-        CertData::Pem(bytes) => {
-            let x509 = X509::from_pem(bytes)?;
-            Ok(x509.serial_number().to_bn()?.to_vec())
-        }
-        CertData::Pkcs12(bytes) => {
-            let encrypted_p12 = Pkcs12::from_der(bytes)?;
-            let Some(inner) = encrypted_p12.parse2(&cert.password)?.cert else {
-                return Err(anyhow!("No certificate found in PKCS#12"));
-            };
-            Ok(inner.serial_number().to_bn()?.to_vec())
-        }
-        CertData::SshBundle(_) => Err(anyhow!("SSH certificates not supported here")),
-    }
+pub(crate) fn extract_pem_serial_number(pem: &Vec<u8>) -> Result<Vec<u8>> {
+    let x509 = X509::from_pem(pem)?;
+    Ok(x509.serial_number().to_bn()?.to_vec())
+}
+
+pub(crate) fn extract_pkcs12_serial_number(pkcs12: &Vec<u8>, password: &str) -> Result<Vec<u8>> {
+    let encrypted_p12 = Pkcs12::from_der(pkcs12)?;
+    let Some(inner) = encrypted_p12.parse2(password)?.cert else {
+        return Err(anyhow!("No certificate found in PKCS#12"));
+    };
+    Ok(inner.serial_number().to_bn()?.to_vec())
 }
 
 #[cfg(not(feature = "test-mode"))]

--- a/backend/src/constants.rs
+++ b/backend/src/constants.rs
@@ -14,6 +14,10 @@ pub(crate) const CA_SSH_FILE_PATH: &str = "./ca/ca-ssh.cert";
 pub(crate) const CRL_DIR_PATH: &str = "./crl";
 #[cfg(not(feature = "test-mode"))]
 pub(crate) const CRL_FILE_PATTERN: &str = "./crl/crl-{}.crl";
+#[cfg(not(feature = "test-mode"))]
+pub(crate) const KRL_DIR_PATH: &str = "./krl";
+#[cfg(not(feature = "test-mode"))]
+pub(crate) const KRL_FILE_PATTERN: &str = "./krl/krl-{}.krl";
 pub(crate) const API_PORT: u16 = 3737;
 pub const VAULTLS_VERSION: &str = formatcp!("v{}", env!("CARGO_PKG_VERSION"));
 

--- a/backend/tests/api/api_test_functionality.rs
+++ b/backend/tests/api/api_test_functionality.rs
@@ -1,3 +1,6 @@
+use std::env::temp_dir;
+use std::fs;
+use std::process::Command;
 use x509_parser::revocation_list::CertificateRevocationList;
 use crate::common::constants::*;
 use crate::common::helper::{extract_ssh_cert_key_bundle, get_timestamp_ms, get_timestamp_s};
@@ -729,6 +732,24 @@ async fn test_ssh_revocation_and_krl() -> Result<()> {
     // Minimal verification that serial is in KRL
     let serial_bytes = serial.to_be_bytes();
     assert!(krl_data.windows(serial_bytes.len()).any(|window| window == serial_bytes));
+
+    let mut krl_path = temp_dir();
+    krl_path.push(format!("krl-{}.krl", 2));
+
+    let mut cert_path = temp_dir();
+    cert_path.push(format!("ssh-{}.pub", 1));
+    fs::write(&cert_path, cert_bytes)?;
+
+    let output = Command::new("ssh-keygen")
+        .arg("-Q") // Query the KRL
+        .arg("-f")
+        .arg(krl_path.as_path())
+        .arg(cert_path.as_path())
+        .output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout.contains("REVOKED"));
 
     Ok(())
 }

--- a/backend/tests/api/api_test_functionality.rs
+++ b/backend/tests/api/api_test_functionality.rs
@@ -691,3 +691,44 @@ async fn establish_tls_connection(
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_ssh_revocation_and_krl() -> Result<()> {
+    let client = VaulTLSClient::new_authenticated().await;
+    client.create_ssh_ca().await?;
+    let _ = client.create_ssh_client_cert().await?;
+
+    // Download SSH certificate to get serial
+    let request = client.get("/certificates/1/download");
+    let response = request.dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let zip_data = response.into_bytes().await.unwrap();
+    
+    let reader = std::io::Cursor::new(zip_data);
+    let mut zip = zip::ZipArchive::new(reader)?;
+    let mut cert_file = zip.by_name(&format!("{}.pub", TEST_SSH_CLIENT_CERT_NAME))?;
+    let mut cert_bytes = Vec::new();
+    use std::io::Read;
+    cert_file.read_to_end(&mut cert_bytes)?;
+    let cert_str = String::from_utf8_lossy(&cert_bytes);
+    let ssh_cert = ssh_key::Certificate::from_openssh(&cert_str)?;
+    let serial = ssh_cert.serial();
+
+    // Revoke SSH certificate
+    let request = client.post("/certificates/1/revoke");
+    let response = request.dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+
+    // Check KRL
+    let request = client.get("/certificates/ca/2/crl");
+    let response = request.dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let krl_data = response.into_bytes().await.unwrap();
+
+    assert!(krl_data.starts_with(b"SSHKRL"));
+    // Minimal verification that serial is in KRL
+    let serial_bytes = serial.to_be_bytes();
+    assert!(krl_data.windows(serial_bytes.len()).any(|window| window == serial_bytes));
+
+    Ok(())
+}

--- a/frontend/src/components/CATab.vue
+++ b/frontend/src/components/CATab.vue
@@ -61,6 +61,14 @@
                 </ul>
               </div>
               <button
+                  v-if="ca.ca_type === CAType.SSH"
+                  :id="'KRLButton-' + ca.id"
+                  class="btn btn-outline-primary btn-sm flex-grow-1"
+                  @click="downloadCRL(ca.id)"
+              >
+                {{ $t('ca.krl') }}
+              </button>
+              <button
                   :id="'DeleteButton-' + ca.id"
                   v-if="authStore.isAdmin"
                   class="btn btn-danger btn-sm flex-grow-1"

--- a/frontend/src/components/OverviewTab.vue
+++ b/frontend/src/components/OverviewTab.vue
@@ -93,7 +93,6 @@
                   {{ $t('common.download') }}
                 </button>
                 <button
-                    v-if="cert.certificate_type === CertificateType.TLSClient || cert.certificate_type === CertificateType.TLSServer"
                     class="btn btn-warning btn-sm flex-grow-1"
                     @click="confirmRevocation(cert)"
                 >
@@ -437,7 +436,7 @@
             <p>
               {{ $t('overview.deleteModal.confirm', { name: certToDelete?.name.cn }) }}
             </p>
-            <p v-if="certToDelete?.certificate_type === CertificateType.TLSClient || certToDelete?.certificate_type === CertificateType.TLSServer" class="text-warning">
+            <p class="text-warning">
               <small>{{ $t('overview.deleteModal.disclaimer') }}</small>
             </p>
           </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -106,12 +106,13 @@
     "deleteModal": {
       "title": "Delete Certificate",
       "confirm": "Are you sure you want to delete the certificate {name}?",
-      "disclaimer": "Disclaimer: Deleting the certificate will remove it from CRL creation since no information on deleted certificates is kept."
+      "disclaimer": "Disclaimer: Deleting the certificate will remove it from CRL/KRL creation since no information on deleted certificates is kept."
     }
   },
   "ca": {
     "title": "Certificate Authorities",
     "crl": "CRL",
+    "krl": "KRL",
     "toggle_dropdown": "Toggle Dropdown",
     "der_format": "DER Format",
     "pem_format": "PEM Format",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -106,12 +106,13 @@
     "deleteModal": {
       "title": "Eliminar certificado",
       "confirm": "¿Está seguro de que desea eliminar el certificado {name}?",
-      "disclaimer": "Aviso: Eliminar el certificado lo eliminará de la generación de CRL ya que no se conserva información sobre los certificados eliminados."
+      "disclaimer": "Aviso: Eliminar el certificado lo eliminará de la generación de CRL/KRL ya que no se conserva información sobre los certificados eliminados."
     }
   },
   "ca": {
     "title": "Autoridades de Certificación",
     "crl": "CRL",
+    "krl": "KRL",
     "toggle_dropdown": "Alternar menú",
     "der_format": "Formato DER",
     "pem_format": "Formato PEM",


### PR DESCRIPTION
This PR adds the ability to revoke and not just delete SSH certificates. Since the ssh_key library does not support Key Revocation Lists (KRL) we need to manually encode the file.

Fixes #194 