### PR TITLE
backend: Add extensions to user ssh cert

### DIFF
--- a/backend/src/certs/ssh_cert.rs
+++ b/backend/src/certs/ssh_cert.rs
@@ -148,6 +148,11 @@ impl SSHCertificateBuilder {
             cert_builder.valid_principal(principal)?;
         }
 
+        // Attach some standard cert extensions that are normal for home lab usage
+        cert_builder.extension("permit-pty", "")?;
+        cert_builder.extension("permit-port-forwarding", "")?;
+        cert_builder.extension("permit-user-rc", "")?;
+
         let cert = cert_builder.sign(&ca_key)?;
         trace!("SSH certificate signed with: {}", ca_key.fingerprint(Default::default()));
 


### PR DESCRIPTION
Per default OpenSSH certificates employ a deny-all approach. For a home lab usecase permissions such as being able to get a PTY or forwarding ports are expected. Add necessary extensions to allow normal usage.

Fixes #198 