### PR TITLE
frontend/backend: Add support for importing CA and user certificates

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "once_cell",
  "openidconnect",
  "openssl",
+ "openssl-sys",
  "parking_lot",
  "passwords",
  "r2d2",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,6 +28,7 @@ rusqlite = { version = "0.39.0", features = ["bundled-sqlcipher"] }
 r2d2 = "0.8.10"
 r2d2_sqlite = { version = "0.34.0", features = ["bundled-sqlcipher"] }
 openssl = "0.10.80"
+openssl-sys = "0.9.106"
 argon2 = "0.5.3"
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
 openidconnect = "4.0.1"
@@ -50,6 +51,7 @@ uuid = { version = "1.23.2", features = ["v4"] }
 ssh-key = { version = "0.6.7", features = ["ed25519", "alloc", "serde", "encryption"] }
 rand = "0.10.1"
 zip = "8.6.0"
+x509-parser = "0.18.1"
 rand_core = "0.10.1"
 reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls"] }
 hickory-resolver = { version = "0.26.1", features = ["tokio", "system-config", "tls-ring", "rustls-platform-verifier"] }
@@ -59,6 +61,5 @@ time = "0.3.47"
 base64 = "0.22.1"
 
 [dev-dependencies]
-x509-parser = "0.18.1"
 rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
 tokio-rustls = "0.26.4"

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use std::env;
 use openidconnect::{Nonce, PkceCodeVerifier};
 use rocket_okapi::openapi;
@@ -11,9 +13,9 @@ use crate::auth::password_auth::Password;
 use crate::auth::session_auth::{generate_token, invalidate_token, Authenticated, AuthenticatedPrivileged};
 use crate::certs::common::{get_password, save_ca, Certificate, CA};
 use crate::certs::ssh_cert::{create_and_save_krl, create_krl, get_ssh_pem, retrieve_krl, SSHCertificateBuilder};
-use crate::certs::tls_cert::{create_and_save_crl, create_crl, get_timestamp, get_tls_pem, retrieve_crl, save_crl, TLSCertificateBuilder};
+use crate::certs::tls_cert::{create_and_save_crl, create_crl, get_timestamp, get_tls_pem, parse_ca, parse_p12, retrieve_crl, save_crl, TLSCertificateBuilder};
 use crate::constants::VAULTLS_VERSION;
-use crate::data::api::{CallbackQuery, ChangePasswordRequest, CreateCARequest, CreateUserCertificateRequest, CreateUserRequest, DownloadResponse, IsSetupResponse, LoginRequest, SetupRequest};
+use crate::data::api::{CallbackQuery, ChangePasswordRequest, CreateCARequest, CreateUserCertificateRequest, CreateUserRequest, DownloadResponse, ImportCARequest, ImportUserCertificateRequest, IsSetupResponse, LoginRequest, SetupRequest};
 use crate::data::enums::{CAType, CertificateType, DataFormat, PasswordRule, TimespanUnit, UserRole};
 use crate::data::error::ApiError;
 use crate::data::objects::{AppState, Name, User};
@@ -320,6 +322,93 @@ pub(crate) async fn get_current_user(
 ) -> Result<Json<User>, ApiError> {
     let user = state.db.get_user(authentication.claims.id).await?;
     Ok(Json(user))
+}
+
+#[openapi(tag = "CA")]
+#[post("/certificates/ca/import", format = "json", data = "<payload>")]
+/// Import an existing CA.
+/// `cert` and `key` can be PEM-encoded strings or base64-encoded DER-encoded binary data.
+/// `crl` (optional) can also be PEM or base64 DER.
+/// The `format` field specifies whether the input is `PEM` or `DER`.
+/// If `format` is `DER`, the binary data must be base64-encoded.
+pub(crate) async fn import_ca(
+    state: &State<AppState>,
+    payload: Json<ImportCARequest>,
+    _authentication: AuthenticatedPrivileged
+) -> Result<Json<i64>, ApiError> {
+    let cert_bytes = match payload.format {
+        DataFormat::PEM => payload.cert.as_bytes().to_vec(),
+        DataFormat::DER => BASE64_STANDARD.decode(&payload.cert).map_err(|e| ApiError::BadRequest(format!("Invalid base64 in cert: {}", e)))?,
+    };
+
+    let key_bytes = match payload.format {
+        DataFormat::PEM => payload.key.as_bytes().to_vec(),
+        DataFormat::DER => BASE64_STANDARD.decode(&payload.key).map_err(|e| ApiError::BadRequest(format!("Invalid base64 in key: {}", e)))?,
+    };
+
+    let mut crl_number = 0;
+    let mut crl_bytes = Vec::new();
+
+    if let Some(crl_str) = &payload.crl {
+        crl_bytes = match payload.format {
+            DataFormat::PEM => crl_str.as_bytes().to_vec(),
+            DataFormat::DER => BASE64_STANDARD.decode(crl_str).map_err(|e| ApiError::BadRequest(format!("Invalid base64 in CRL: {}", e)))?,
+        };
+        debug!("Extracting CRL number from CRL");
+        match crate::certs::tls_cert::extract_crl_number(&crl_bytes, payload.format) {
+            Ok(extracted_crl_number) => {
+                info!(extracted_crl_number, "Extracted CRL number from imported CRL");
+                crl_number = extracted_crl_number;
+            }
+            Err(e) => {
+                warn!(error = e.to_string(), "Failed to extract CRL number from imported CRL");
+            }
+        }
+    }
+
+    let mut ca = parse_ca(&cert_bytes, &key_bytes, payload.format, crl_number)?;
+    ca = state.db.insert_ca(ca).await?;
+    save_ca(&ca)?;
+
+    if payload.crl.is_some() {
+        save_crl(crl_bytes, ca.id)?;
+    }
+
+    Ok(Json(ca.id))
+}
+
+#[openapi(tag = "Certificates")]
+#[post("/certificates/import", format = "json", data = "<payload>")]
+/// Import an existing user certificate from a PKCS#12 file.
+/// `p12` must be a base64-encoded PKCS#12 binary file if `format` is `DER`, or a PEM-encoded PKCS#12 file if `format` is `PEM`.
+/// If `format` is `DER`, the binary data must be base64-encoded.
+pub(crate) async fn import_user_certificate(
+    state: &State<AppState>,
+    payload: Json<ImportUserCertificateRequest>,
+    _authentication: AuthenticatedPrivileged
+) -> Result<Json<Certificate>, ApiError> {
+    let p12_bytes = match payload.format {
+        DataFormat::PEM => payload.p12.as_bytes().to_vec(),
+        DataFormat::DER => BASE64_STANDARD.decode(&payload.p12).map_err(|e| ApiError::BadRequest(format!("Invalid base64 in p12: {}", e)))?,
+    };
+    let (name, created_on, valid_until, _cert_der) = parse_p12(&p12_bytes, &payload.password)?;
+
+    let cert = Certificate {
+        id: -1,
+        name,
+        created_on,
+        valid_until,
+        certificate_type: payload.cert_type,
+        user_id: payload.user_id,
+        renew_method: payload.renew_method,
+        ca_id: payload.ca_id,
+        revoked_at: None,
+        data: crate::data::enums::CertData::Pkcs12(p12_bytes),
+        password: payload.password.clone(),
+    };
+
+    let inserted_cert = state.db.insert_user_cert(cert).await?;
+    Ok(Json(inserted_cert))
 }
 
 #[openapi(tag = "Certificates")]

--- a/backend/src/certs/common.rs
+++ b/backend/src/certs/common.rs
@@ -72,7 +72,6 @@ pub struct CA {
     pub cert: Vec<u8>,
     #[serde(skip)]
     pub key: Vec<u8>,
-    #[serde(skip)]
     pub crl_number: i64,
 }
 

--- a/backend/src/certs/tls_cert.rs
+++ b/backend/src/certs/tls_cert.rs
@@ -13,7 +13,7 @@ use openssl::nid::Nid;
 use openssl::pkcs12::Pkcs12;
 use openssl::pkey::{PKey, Private};
 use openssl::stack::Stack;
-use openssl::x509::{X509Name, X509NameBuilder, X509Ref, X509};
+use openssl::x509::{X509Name, X509NameBuilder, X509Ref, X509, X509Crl};
 use openssl::x509::extension::{AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName, SubjectKeyIdentifier};
 use openssl::x509::{X509Builder};
 use openssl::x509::X509Req;
@@ -26,7 +26,7 @@ use crate::ApiError;
 use crate::constants::{CA_DIR_PATH, CA_FILE_PATTERN, CA_TLS_FILE_PATH, CRL_DIR_PATH, CRL_FILE_PATTERN};
 #[cfg(feature = "test-mode")]
 use crate::constants::{CA_DIR_PATH, CA_FILE_PATTERN, CA_TLS_FILE_PATH};
-use crate::data::enums::{CertData, CertificateRenewMethod, CertificateType, TimespanUnit};
+use crate::data::enums::{CertData, CertificateRenewMethod, CertificateType, DataFormat, TimespanUnit};
 use crate::data::enums::CertificateType::{TLSClient, TLSServer};
 use crate::certs::common::{Certificate, CA};
 use crate::data::enums::CAType::TLS;
@@ -441,7 +441,7 @@ fn extract_ski(cert: &X509Ref) -> Result<Vec<u8>, ErrorStack> {
     Ok(ext.as_slice().to_vec())
 }
 
-pub(crate) fn create_crl(ca: &mut CA, revoked_certs: Vec<(Vec<u8>, i64)>, crl_next_update_hours: i64) -> Result<Vec<u8>> {
+pub fn create_crl(ca: &mut CA, revoked_certs: Vec<(Vec<u8>, i64)>, crl_next_update_hours: i64) -> Result<Vec<u8>> {
     let ca_key_pair = KeyPair::try_from(ca.key.clone())?;
     let cert_der = CertificateDer::from(ca.cert.clone());
     let issuer = Issuer::from_ca_cert_der(&cert_der, ca_key_pair)?;
@@ -523,4 +523,95 @@ pub(crate) fn get_dns_names(cert: &Certificate) -> Result<Vec<String>, anyhow::E
         }
         CertData::SshBundle(_) => Ok(vec![]),
     }
+}
+
+pub fn parse_ca(cert_bytes: &[u8], key_bytes: &[u8], data_format: DataFormat, crl_number: i64) -> Result<CA> {
+    let cert = match data_format {
+        DataFormat::DER => X509::from_der(cert_bytes)?,
+        DataFormat::PEM => X509::from_pem(cert_bytes)?
+    };
+
+    let key = match data_format {
+        DataFormat::DER => PKey::private_key_from_der(key_bytes)?,
+        DataFormat::PEM => PKey::private_key_from_pem(key_bytes)?
+    };
+
+    let subject = cert.subject_name();
+    let cn = subject.entries_by_nid(Nid::COMMONNAME)
+        .next()
+        .ok_or_else(|| anyhow!("No CN in CA certificate"))?
+        .data()
+        .as_utf8()?
+        .to_string();
+
+    let ou = subject.entries_by_nid(Nid::ORGANIZATIONALUNITNAME)
+        .next()
+        .and_then(|e| e.data().as_utf8().ok().map(|s| s.to_string()));
+    
+    let created_on_unix = asn1_time_to_unix(cert.not_before())?;
+    let valid_until_unix = asn1_time_to_unix(cert.not_after())?;
+
+    Ok(CA {
+        id: -1,
+        name: Name { cn, ou },
+        created_on: created_on_unix,
+        valid_until: valid_until_unix,
+        ca_type: TLS,
+        cert: cert.to_der()?,
+        key: key.private_key_to_der()?,
+        crl_number,
+    })
+}
+
+pub fn parse_p12(p12_bytes: &[u8], password: &str) -> Result<(Name, i64, i64, Vec<u8>)> {
+    let p12 = Pkcs12::from_der(p12_bytes)?;
+    let parsed = p12.parse2(password)?;
+    let cert = parsed.cert.ok_or_else(|| anyhow!("No certificate in PKCS#12"))?;
+    
+    let subject = cert.subject_name();
+    let cn = subject.entries_by_nid(Nid::COMMONNAME)
+        .next()
+        .ok_or_else(|| anyhow!("No CN in certificate"))?
+        .data()
+        .as_utf8()?
+        .to_string();
+
+    let ou = subject.entries_by_nid(Nid::ORGANIZATIONALUNITNAME)
+        .next()
+        .and_then(|e| e.data().as_utf8().ok().map(|s| s.to_string()));
+
+    let created_on_unix = asn1_time_to_unix(cert.not_before())?;
+    let valid_until_unix = asn1_time_to_unix(cert.not_after())?;
+
+    Ok((Name { cn, ou }, created_on_unix, valid_until_unix, cert.to_der()?))
+}
+
+pub fn extract_crl_number(crl_bytes: &[u8], format: DataFormat) -> Result<i64> {
+    let crl_der = match format {
+        DataFormat::DER => crl_bytes.to_vec(),
+        DataFormat::PEM => {
+            let crl = X509Crl::from_pem(crl_bytes)?;
+            crl.to_der()?
+        }
+    };
+
+    use x509_parser::prelude::FromDer;
+    let (_, crl) = x509_parser::revocation_list::CertificateRevocationList::from_der(&crl_der)
+        .map_err(|e| anyhow!("Failed to parse CRL with x509-parser: {}", e))?;
+    
+    for ext in crl.extensions() {
+        if let x509_parser::extensions::ParsedExtension::CRLNumber(num) = ext.parsed_extension() {
+            let crl_number = num.to_string().parse::<i64>()?;
+            return Ok(crl_number);
+        }
+    }
+
+    Err(anyhow!("No CRL number extension in CRL"))
+}
+
+fn asn1_time_to_unix(time: &openssl::asn1::Asn1TimeRef) -> Result<i64> {
+    // We can't directly convert to UNIX, need to compare with Epoch
+    let epoch = Asn1Time::from_unix(0)?;
+    let diff = time.diff(&epoch)?;
+    Ok((diff.days as i64 * 24 * 3600 + diff.secs as i64) * 1000)
 }

--- a/backend/src/certs/tls_cert.rs
+++ b/backend/src/certs/tls_cert.rs
@@ -612,6 +612,6 @@ pub fn extract_crl_number(crl_bytes: &[u8], format: DataFormat) -> Result<i64> {
 fn asn1_time_to_unix(time: &openssl::asn1::Asn1TimeRef) -> Result<i64> {
     // We can't directly convert to UNIX, need to compare with Epoch
     let epoch = Asn1Time::from_unix(0)?;
-    let diff = time.diff(&epoch)?;
+    let diff = epoch.diff(time)?;
     Ok((diff.days as i64 * 24 * 3600 + diff.secs as i64) * 1000)
 }

--- a/backend/src/data/api.rs
+++ b/backend/src/data/api.rs
@@ -8,7 +8,7 @@ use rocket_okapi::okapi::schemars;
 use rocket_okapi::{okapi, JsonSchema, OpenApiError};
 use rocket_okapi::okapi::openapi3::{Responses, Response as OAResponse, MediaType, RefOr};
 use rocket_okapi::response::OpenApiResponderInner;
-use crate::data::enums::{CAType, CertificateRenewMethod, CertificateType, TimespanUnit, UserRole};
+use crate::data::enums::{CAType, CertificateRenewMethod, CertificateType, DataFormat, TimespanUnit, UserRole};
 use crate::data::objects::Name;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -133,4 +133,23 @@ pub struct CreateUserRequest {
     pub user_email: String,
     pub password: Option<String>,
     pub role: UserRole
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct ImportCARequest {
+    pub cert: String, // PEM or base64 DER
+    pub key: String,  // PEM or base64 DER
+    pub crl: Option<String>, // PEM or base64 DER
+    pub format: DataFormat,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct ImportUserCertificateRequest {
+    pub p12: String, // base64 DER
+    pub password: String,
+    pub user_id: i64,
+    pub ca_id: i64,
+    pub renew_method: CertificateRenewMethod,
+    pub cert_type: CertificateType,
+    pub format: DataFormat,
 }

--- a/backend/src/data/enums.rs
+++ b/backend/src/data/enums.rs
@@ -152,7 +152,7 @@ pub enum TimespanUnit {
     Hour = 3
 }
 
-#[derive(serde::Deserialize, rocket::form::FromFormField, rocket_okapi::JsonSchema, Clone, Debug, Copy, PartialEq, Eq, Default)]
+#[derive(serde::Deserialize, serde::Serialize, rocket::form::FromFormField, rocket_okapi::JsonSchema, Clone, Debug, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum DataFormat {
     #[default]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -171,6 +171,8 @@ pub async fn create_rocket() -> Rocket<Build> {
             openapi_get_routes![
                 version,
                 get_certificates,
+                import_ca,
+                import_user_certificate,
                 create_ca,
                 create_user_certificate,
                 get_all_ca,
@@ -261,6 +263,8 @@ pub async fn create_test_rocket() -> Rocket<Build> {
             openapi_get_routes![
                 version,
                 get_certificates,
+                import_ca,
+                import_user_certificate,
                 create_user_certificate,
                 create_ca,
                 get_all_ca,

--- a/backend/tests/api/api_test_functionality.rs
+++ b/backend/tests/api/api_test_functionality.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use std::env::temp_dir;
 use std::fs;
 use std::process::Command;
@@ -735,6 +737,7 @@ async fn test_ssh_revocation_and_krl() -> Result<()> {
 
     let mut krl_path = temp_dir();
     krl_path.push(format!("krl-{}.krl", 2));
+    fs::write(&krl_path, &krl_data)?;
 
     let mut cert_path = temp_dir();
     cert_path.push(format!("ssh-{}.pub", 1));
@@ -750,6 +753,139 @@ async fn test_ssh_revocation_and_krl() -> Result<()> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert_eq!(output.status.code(), Some(1));
     assert!(stdout.contains("REVOKED"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_ca_import_with_crl_extraction() -> Result<()> {
+    let client = VaulTLSClient::new_authenticated().await;
+
+    // 1. Create a CA manually using openssl
+    let rsa = openssl::rsa::Rsa::generate(2048)?;
+    let pkey = openssl::pkey::PKey::from_rsa(rsa)?;
+    let mut name_builder = openssl::x509::X509NameBuilder::new()?;
+    name_builder.append_entry_by_text("CN", "Import Test CA")?;
+    let name = name_builder.build();
+
+    let mut builder = X509::builder()?;
+    builder.set_version(2)?;
+    builder.set_subject_name(&name)?;
+    builder.set_issuer_name(&name)?;
+    builder.set_pubkey(&pkey)?;
+    let not_before = openssl::asn1::Asn1Time::days_from_now(0)?;
+    let not_after = openssl::asn1::Asn1Time::days_from_now(365)?;
+    builder.set_not_before(&not_before)?;
+    builder.set_not_after(&not_after)?;
+    let basic_constraints = openssl::x509::extension::BasicConstraints::new().ca().build()?;
+    builder.append_extension(basic_constraints)?;
+    builder.sign(&pkey, openssl::hash::MessageDigest::sha256())?;
+    let cert = builder.build();
+
+    let cert_pem = String::from_utf8(cert.to_pem()?)?;
+    let key_pem = String::from_utf8(pkey.private_key_to_pem_pkcs8()?)?;
+
+    // Create a CRL with a specific CRL number using rcgen since openssl-rust is painful here
+    let now = OffsetDateTime::now_utc();
+    let crl_params = rcgen::CertificateRevocationListParams {
+        this_update: now,
+        next_update: now + time::Duration::days(30),
+        crl_number: rcgen::SerialNumber::from(123u64),
+        issuing_distribution_point: None,
+        revoked_certs: vec![],
+        key_identifier_method: rcgen::KeyIdMethod::Sha256,
+    };
+    
+    // We need the key and cert in rcgen format
+    let key_pair = rcgen::KeyPair::from_pem(&key_pem)?;
+    let ca_cert_der = rustls_pki_types::CertificateDer::from(cert.to_der()?);
+    let issuer = rcgen::Issuer::from_ca_cert_der(&ca_cert_der, key_pair)?;
+    
+    let crl = crl_params.signed_by(&issuer)?;
+    let crl_pem = crl.pem()?;
+
+    let payload = serde_json::json!({
+        "cert": cert_pem,
+        "key": key_pem,
+        "crl": crl_pem,
+        "format": "pem"
+    });
+
+    let response = client.post("/certificates/ca/import")
+        .body(payload.to_string())
+        .header(ContentType::JSON)
+        .dispatch().await;
+
+    assert_eq!(response.status(), Status::Ok);
+    let imported_ca_id: i64 = serde_json::from_str(&response.into_string().await.unwrap())?;
+
+    // 3. Verify CRL number in DB
+    let cas = client.get_all_ca().await?;
+    let imported_ca = cas.iter().find(|ca| ca.id == imported_ca_id).expect("Imported CA not found");
+    
+    assert_eq!(imported_ca.crl_number, 123);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_user_cert_import() -> Result<()> {
+    let client = VaulTLSClient::new_authenticated().await;
+
+    // 1. Create a PKCS#12 file manually using openssl
+    let rsa = openssl::rsa::Rsa::generate(2048)?;
+    let pkey = openssl::pkey::PKey::from_rsa(rsa)?;
+    let mut name_builder = openssl::x509::X509NameBuilder::new()?;
+    name_builder.append_entry_by_text("CN", "Imported User Cert")?;
+    let name = name_builder.build();
+
+    let mut builder = X509::builder()?;
+    builder.set_version(2)?;
+    builder.set_subject_name(&name)?;
+    builder.set_issuer_name(&name)?; // Self-signed for simplicity in test
+    builder.set_pubkey(&pkey)?;
+    let not_before = openssl::asn1::Asn1Time::days_from_now(0)?;
+    let not_after = openssl::asn1::Asn1Time::days_from_now(365)?;
+    builder.set_not_before(&not_before)?;
+    builder.set_not_after(&not_after)?;
+    builder.sign(&pkey, openssl::hash::MessageDigest::sha256())?;
+    let cert = builder.build();
+
+    let p12_password = "test-password";
+    let p12 = Pkcs12::builder()
+        .name("Imported User Cert")
+        .cert(&cert)
+        .pkey(&pkey)
+        .build2(p12_password)?;
+    let p12_der = p12.to_der()?;
+    let p12_base64 = BASE64_STANDARD.encode(&p12_der);
+
+    // 2. Import via API
+    let payload = serde_json::json!({
+        "p12": p12_base64,
+        "password": p12_password,
+        "user_id": 1,
+        "ca_id": 1,
+        "renew_method": 0, // None
+        "cert_type": 0,    // TLSClient
+        "format": "der"
+    });
+
+    let response = client.post("/certificates/import")
+        .body(payload.to_string())
+        .header(ContentType::JSON)
+        .dispatch().await;
+
+    assert_eq!(response.status(), Status::Ok);
+    let imported_cert: Certificate = serde_json::from_str(&response.into_string().await.unwrap())?;
+
+    assert_eq!(imported_cert.name.cn, "Imported User Cert");
+    assert_eq!(imported_cert.user_id, 1);
+    assert_eq!(imported_cert.ca_id, 1);
+
+    // 3. Verify it's in the list
+    let certs = client.get_certificates().await?;
+    assert!(certs.iter().any(|c| c.id == imported_cert.id));
 
     Ok(())
 }

--- a/backend/tests/common/test_client.rs
+++ b/backend/tests/common/test_client.rs
@@ -295,6 +295,16 @@ impl VaulTLSClient {
         Ok(serde_json::from_str(&response.into_string().await.unwrap())?)
     }
 
+    pub(crate) async fn get_certificates(&self) -> Result<Vec<Certificate>> {
+        let request = self
+            .get("/certificates");
+        let response = request.dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.content_type(), Some(ContentType::JSON));
+
+        Ok(serde_json::from_str(&response.into_string().await.unwrap())?)
+    }
+
     pub(crate) async fn create_second_ca(&self) -> Result<()> {
         let data = CreateCARequest {
             ca_name: TEST_SECOND_CA_NAME.to_string().into(),

--- a/frontend/src/api/cas.ts
+++ b/frontend/src/api/cas.ts
@@ -1,5 +1,5 @@
 import ApiClient from "@/api/ApiClient.ts";
-import type {CA, CARequirements} from "@/types/CA.ts";
+import type {CA, CARequirements, ImportCARequest} from "@/types/CA.ts";
 
 export const fetchCAs = async (): Promise<CA[]> => {
     return await ApiClient.get<CA[]>(`/certificates/ca`);
@@ -7,6 +7,10 @@ export const fetchCAs = async (): Promise<CA[]> => {
 
 export const createCA = async (certReq: CARequirements): Promise<number> => {
     return await ApiClient.post<number>('/certificates/ca', certReq);
+};
+
+export const importCA = async (importReq: ImportCARequest): Promise<number> => {
+    return await ApiClient.post<number>('/certificates/ca/import', importReq);
 };
 
 export const downloadCAByID = async (id: number): Promise<void> => {

--- a/frontend/src/api/certificates.ts
+++ b/frontend/src/api/certificates.ts
@@ -1,6 +1,6 @@
 import ApiClient from './ApiClient';
 import type {Certificate} from '@/types/Certificate';
-import type {CertificateRequirements} from "@/types/CertificateRequirements.ts";
+import type {CertificateRequirements, ImportUserCertificateRequest} from "@/types/CertificateRequirements.ts";
 
 export const fetchCertificates = async (): Promise<Certificate[]> => {
     return await ApiClient.get<Certificate[]>('/certificates');
@@ -17,6 +17,10 @@ export const downloadCertificate = async (id: number): Promise<void> => {
 export const createCertificate = async (certReq: CertificateRequirements): Promise<number> => {
     const cert = await ApiClient.post<Certificate>('/certificates', certReq);
     return cert.id;
+};
+
+export const importCertificate = async (importReq: ImportUserCertificateRequest): Promise<Certificate> => {
+    return await ApiClient.post<Certificate>('/certificates/import', importReq);
 };
 
 export const deleteCertificate = async (id: number): Promise<void> => {

--- a/frontend/src/components/CATab.vue
+++ b/frontend/src/components/CATab.vue
@@ -92,6 +92,15 @@
       {{ $t('ca.createCa') }}
     </button>
 
+    <button
+        id="ImportCAButton"
+        v-if="authStore.isAdmin"
+        class="btn btn-outline-primary mx-1"
+        @click="showImportModal"
+    >
+      {{ $t('ca.importCa') }}
+    </button>
+
     <div v-if="loading" class="text-center mt-3">{{ $t('ca.loadingCas') }}</div>
     <div v-if="error" class="alert alert-danger mt-3">{{ error }}</div>
 
@@ -224,13 +233,85 @@
         </div>
       </div>
     </div>
+
+    <!-- Import CA Modal -->
+    <div
+        v-if="isImportModalVisible"
+        class="modal show d-block"
+        tabindex="-1"
+        style="background: rgba(0, 0, 0, 0.5)"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">{{ $t('ca.importModal.title') }}</h5>
+            <button type="button" class="btn-close" @click="closeImportModal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="importFormat" class="form-label">{{ $t('common.format') }}</label>
+              <select class="form-select" id="importFormat" v-model="importReq.format">
+                <option :value="DataFormat.PEM">PEM</option>
+                <option :value="DataFormat.DER">DER (Base64)</option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="importCert" class="form-label">{{ $t('ca.importModal.cert') }}</label>
+              <textarea
+                  id="importCert"
+                  v-model="importReq.cert"
+                  class="form-control"
+                  rows="3"
+                  :placeholder="importReq.format === DataFormat.PEM ? '-----BEGIN CERTIFICATE-----...' : 'Base64 encoded DER...'"
+                  required
+              ></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="importKey" class="form-label">{{ $t('ca.importModal.key') }}</label>
+              <textarea
+                  id="importKey"
+                  v-model="importReq.key"
+                  class="form-control"
+                  rows="3"
+                  :placeholder="importReq.format === DataFormat.PEM ? '-----BEGIN PRIVATE KEY-----...' : 'Base64 encoded DER...'"
+                  required
+              ></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="importCrl" class="form-label">{{ $t('ca.importModal.crl') }} ({{ $t('common.optional') }})</label>
+              <textarea
+                  id="importCrl"
+                  v-model="importReq.crl"
+                  class="form-control"
+                  rows="2"
+                  :placeholder="importReq.format === DataFormat.PEM ? '-----BEGIN X509 CRL-----...' : 'Base64 encoded DER...'"
+              ></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" @click="closeImportModal">
+              {{ $t('common.cancel') }}
+            </button>
+            <button
+                type="button"
+                class="btn btn-primary"
+                :disabled="loading || !importReq.cert || !importReq.key"
+                @click="doImportCA"
+            >
+              <span v-if="loading">{{ $t('common.importing') }}</span>
+              <span v-else>{{ $t('common.import') }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import {computed, onMounted, reactive, ref} from 'vue';
 import {useCAStore} from '@/stores/cas';
-import {type CA, type CARequirements, CAType} from '@/types/CA';
+import {type CA, type CARequirements, CAType, DataFormat, type ImportCARequest} from '@/types/CA';
 import {useAuthStore} from '@/stores/auth';
 import {ValidityUnit} from "@/types/ValidityUnit.ts";
 
@@ -246,6 +327,7 @@ const hasAnyOU = computed(() => Array.from(cas.value.values()).some(ca => ca.nam
 
 const isDeleteModalVisible = ref(false);
 const isCreateModalVisible = ref(false);
+const isImportModalVisible = ref(false);
 const caToDelete = ref<CA | null>(null);
 
 const caReq = reactive<CARequirements>({
@@ -253,6 +335,13 @@ const caReq = reactive<CARequirements>({
   ca_type: CAType.TLS,
   validity_duration: undefined,
   validity_unit: ValidityUnit.Year
+});
+
+const importReq = reactive<ImportCARequest>({
+  cert: '',
+  key: '',
+  crl: '',
+  format: DataFormat.PEM
 });
 
 const showOUField = ref(false);
@@ -273,9 +362,26 @@ const closeCreateModal = () => {
   showOUField.value = false;
 };
 
+const showImportModal = () => {
+  isImportModalVisible.value = true;
+};
+
+const closeImportModal = () => {
+  isImportModalVisible.value = false;
+  importReq.cert = '';
+  importReq.key = '';
+  importReq.crl = '';
+  importReq.format = DataFormat.PEM;
+};
+
 const createCA = async () => {
   await caStore.createCA(caReq);
   closeCreateModal();
+};
+
+const doImportCA = async () => {
+  await caStore.importCA(importReq);
+  closeImportModal();
 };
 
 const confirmDeletion = (ca: CA) => {

--- a/frontend/src/components/OverviewTab.vue
+++ b/frontend/src/components/OverviewTab.vue
@@ -121,6 +121,15 @@
       {{ $t('overview.createCertificate') }}
     </button>
 
+    <button
+        id="ImportCertificateButton"
+        v-if="authStore.isAdmin"
+        class="btn btn-outline-primary mx-1"
+        @click="showImportModal"
+    >
+      {{ $t('overview.importCertificate') }}
+    </button>
+
     <div v-if="loading" class="text-center mt-3">{{ $t('overview.loadingCerts') }}</div>
     <div v-if="error" class="alert alert-danger mt-3">{{ error }}</div>
 
@@ -451,19 +460,111 @@
         </div>
       </div>
     </div>
+
+    <!-- Import Certificate Modal -->
+    <div
+        v-if="isImportModalVisible"
+        class="modal show d-block"
+        tabindex="-1"
+        style="background: rgba(0, 0, 0, 0.5)"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">{{ $t('overview.importModal.title') }}</h5>
+            <button type="button" class="btn-close" @click="closeImportModal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="importP12" class="form-label">PKCS#12 ({{ importImportReq.format === DataFormat.PEM ? 'PEM' : 'Base64 DER' }})</label>
+              <textarea
+                  id="importP12"
+                  v-model="importImportReq.p12"
+                  class="form-control"
+                  rows="4"
+                  required
+              ></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="importPassword" class="form-label">{{ $t('common.password') }}</label>
+              <input
+                  id="importPassword"
+                  v-model="importImportReq.password"
+                  type="password"
+                  class="form-control"
+                  required
+              />
+            </div>
+            <div class="mb-3">
+              <label for="importFormat" class="form-label">{{ $t('common.format') }}</label>
+              <select class="form-select" id="importFormat" v-model="importImportReq.format">
+                <option :value="DataFormat.DER">DER (Base64)</option>
+                <option :value="DataFormat.PEM">PEM</option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="importUserId" class="form-label">{{ $t('overview.generateModal.user') }}</label>
+              <select id="importUserId" v-model="importImportReq.user_id" class="form-select">
+                <option v-for="user in userStore.users" :key="user.id" :value="user.id">
+                  {{ user.name }}
+                </option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="importCaId" class="form-label">{{ $t('overview.generateModal.ca') }}</label>
+              <select id="importCaId" v-model="importImportReq.ca_id" class="form-select">
+                <option v-for="ca in availableCAsForImport" :key="ca.id" :value="ca.id">
+                  {{ ca.name.cn }} (ID: {{ ca.id }})
+                </option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="importCertType" class="form-label">{{ $t('overview.generateModal.certType') }}</label>
+              <select class="form-select" id="importCertType" v-model="importImportReq.cert_type">
+                <option :value="CertificateType.TLSClient">{{ $t('overview.generateModal.tlsClient') }}</option>
+                <option :value="CertificateType.TLSServer">{{ $t('overview.generateModal.tlsServer') }}</option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="importRenewMethod" class="form-label">{{ $t('overview.generateModal.renewMethod') }}</label>
+              <select class="form-select" id="importRenewMethod" v-model="importImportReq.renew_method">
+                <option :value="CertificateRenewMethod.None">{{ $t('overview.generateModal.renewNone') }}</option>
+                <option :value="CertificateRenewMethod.Notify">{{ $t('overview.generateModal.renewRemind') }}</option>
+                <option :value="CertificateRenewMethod.Renew">{{ $t('overview.generateModal.renewRenew') }}</option>
+                <option :value="CertificateRenewMethod.RenewAndNotify">{{ $t('overview.generateModal.renewAndNotify') }}</option>
+              </select>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" @click="closeImportModal">
+              {{ $t('common.cancel') }}
+            </button>
+            <button
+                type="button"
+                class="btn btn-primary"
+                :disabled="loading || !importImportReq.p12"
+                @click="doImportCertificate"
+            >
+              <span v-if="loading">{{ $t('common.importing') }}</span>
+              <span v-else>{{ $t('common.import') }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 <script setup lang="ts">
 import {computed, onMounted, reactive, ref, watch} from 'vue';
 import {useCertificateStore} from '@/stores/certificates';
 import {type Certificate, CertificateRenewMethod, CertificateType} from "@/types/Certificate";
-import type {CertificateRequirements} from "@/types/CertificateRequirements";
+import type {CertificateRequirements, ImportUserCertificateRequest} from "@/types/CertificateRequirements";
 import {useAuthStore} from "@/stores/auth.ts";
 import {useUserStore} from "@/stores/users.ts";
 import {useSettingsStore} from "@/stores/settings.ts";
 import {PasswordRule} from "@/types/Settings.ts";
 import {useCAStore} from "@/stores/cas.ts";
-import {CAType} from "@/types/CA.ts";
+import {CAType, DataFormat} from "@/types/CA.ts";
 import {ValidityUnit} from "@/types/ValidityUnit.ts";
 // stores
 const certificateStore = useCertificateStore();
@@ -498,6 +599,7 @@ const hasAnyOU = computed(() => Array.from(certificates.value.values()).some(cer
 const isDeleteModalVisible = ref(false);
 const isGenerateModalVisible = ref(false);
 const isRevokeModalVisible = ref(false);
+const isImportModalVisible = ref(false);
 const showRevoked = ref(false);
 
 const certToDelete = ref<Certificate | null>(null);
@@ -521,6 +623,16 @@ const certReq = reactive<CertificateRequirements>({
   ca_id: undefined
 });
 
+const importImportReq = reactive<ImportUserCertificateRequest>({
+  p12: '',
+  password: '',
+  user_id: 0,
+  ca_id: 0,
+  renew_method: CertificateRenewMethod.None,
+  cert_type: CertificateType.TLSClient,
+  format: DataFormat.DER
+});
+
 const showOUField = ref(false);
 
 const isMailValid = computed(() => {
@@ -542,6 +654,10 @@ const availableCAs = computed(() => {
   if (!allowedType) return cas;
 
   return cas.filter(ca => allowedType.includes(ca.ca_type)).sort((a, b) => b.id - a.id);
+});
+
+const availableCAsForImport = computed(() => {
+  return Array.from(caStore.cas.values()).filter(ca => ca.ca_type === CAType.TLS).sort((a, b) => b.id - a.id);
 });
 
 
@@ -575,9 +691,41 @@ const closeGenerateModal = () => {
   showOUField.value = false;
 };
 
+const showImportModal = async () => {
+  await userStore.fetchUsers();
+  await caStore.fetchCAs();
+
+  // Set defaults for import
+  if (userStore.users.length > 0) {
+    importImportReq.user_id = userStore.users[0].id;
+  }
+  const tlsCAs = Array.from(caStore.cas.values()).filter(ca => ca.ca_type === CAType.TLS);
+  if (tlsCAs.length > 0) {
+    importImportReq.ca_id = tlsCAs[0].id;
+  }
+
+  isImportModalVisible.value = true;
+};
+
+const closeImportModal = () => {
+  isImportModalVisible.value = false;
+  importImportReq.p12 = '';
+  importImportReq.password = '';
+  importImportReq.user_id = 0;
+  importImportReq.ca_id = 0;
+  importImportReq.renew_method = CertificateRenewMethod.None;
+  importImportReq.cert_type = CertificateType.TLSClient;
+  importImportReq.format = DataFormat.DER;
+};
+
 const createCertificate = async () => {
     await certificateStore.createCertificate(certReq);
     closeGenerateModal();
+};
+
+const doImportCertificate = async () => {
+  await certificateStore.importCertificate(importImportReq);
+  closeImportModal();
 };
 
 const confirmDeletion = (cert: Certificate) => {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -15,6 +15,10 @@
     "username": "Username",
     "validity": "Validity",
     "creating": "Creating...",
+    "importing": "Importing...",
+    "import": "Import",
+    "optional": "optional",
+    "format": "Format",
     "hideOu": "Hide OU field",
     "addOu": "Add OU (Group)",
     "ouGroup": "OU (Group)",
@@ -63,12 +67,17 @@
     "colRenewMethod": "Renew Method",
     "revoke": "Revoke",
     "createCertificate": "Create New Certificate",
+    "importCertificate": "Import Certificate",
     "loadingCerts": "Loading certificates...",
     "revokedSection": "Revoked Certificates",
     "colCreated": "Created",
     "colValidity": "Validity",
     "colRevoked": "Revoked",
     "noRevokedCerts": "No revoked certificates found.",
+    "importModal": {
+      "title": "Import User Certificate",
+      "uploadFile": "Upload File"
+    },
     "generateModal": {
       "title": "Generate New Certificate",
       "blank": "(Blank)",
@@ -117,8 +126,16 @@
     "der_format": "DER Format",
     "pem_format": "PEM Format",
     "createCa": "Create New CA",
+    "importCa": "Import CA",
     "loadingCas": "Loading CAs...",
     "enterCaCommonName": "Enter CA Common Name",
+    "importModal": {
+      "title": "Import Certificate Authority",
+      "cert": "Certificate (PEM or Base64 DER)",
+      "key": "Private Key (PEM or Base64 DER)",
+      "crl": "CRL (PEM or Base64 DER)",
+      "uploadFile": "Upload File"
+    },
     "createModal": {
       "title": "Create New Certificate Authority",
       "caName": "CA Name (CN)",

--- a/frontend/src/stores/cas.ts
+++ b/frontend/src/stores/cas.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
-import type {CA, CARequirements} from '@/types/CA';
-import {createCA, deleteCA, downloadCAByID, downloadCRL, fetchCAs} from "@/api/cas.ts";
+import type {CA, CARequirements, ImportCARequest} from '@/types/CA';
+import {createCA, deleteCA, downloadCAByID, downloadCRL, fetchCAs, importCA} from "@/api/cas.ts";
 import axios from 'axios';
 
 export const useCAStore = defineStore('ca', {
@@ -67,6 +67,24 @@ export const useCAStore = defineStore('ca', {
                     this.error = 'Failed to create the CA: ' + err.response?.data?.error;
                 } else {
                     this.error = 'Failed to create the CA';
+                }
+                console.error(err);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async importCA(importReq: ImportCARequest): Promise<void> {
+            this.loading = true;
+            this.error = null;
+            try {
+                await importCA(importReq);
+                await this.fetchCAs();
+            } catch (err) {
+                if (axios.isAxiosError(err)) {
+                    this.error = 'Failed to import the CA: ' + err.response?.data?.error;
+                } else {
+                    this.error = 'Failed to import the CA';
                 }
                 console.error(err);
             } finally {

--- a/frontend/src/stores/certificates.ts
+++ b/frontend/src/stores/certificates.ts
@@ -5,10 +5,11 @@ import {
     fetchCertificatePassword,
     downloadCertificate,
     createCertificate,
+    importCertificate,
     deleteCertificate,
     revokeCertificate,
 } from '../api/certificates';
-import type {CertificateRequirements} from "@/types/CertificateRequirements.ts";
+import type {CertificateRequirements, ImportUserCertificateRequest} from "@/types/CertificateRequirements.ts";
 import axios from 'axios';
 
 export const useCertificateStore = defineStore('certificate', {
@@ -94,6 +95,24 @@ export const useCertificateStore = defineStore('certificate', {
                     this.error = 'Failed to create the certificate: ' + err.response?.data?.error;
                 } else {
                     this.error = 'Failed to create the certificate';
+                }
+                console.error(err);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async importCertificate(importReq: ImportUserCertificateRequest): Promise<void> {
+            this.loading = true;
+            this.error = null;
+            try {
+                await importCertificate(importReq);
+                await this.fetchCertificates();
+            } catch (err) {
+                if (axios.isAxiosError(err)) {
+                    this.error = 'Failed to import the certificate: ' + err.response?.data?.error;
+                } else {
+                    this.error = 'Failed to import the certificate';
                 }
                 console.error(err);
             } finally {

--- a/frontend/src/types/CA.ts
+++ b/frontend/src/types/CA.ts
@@ -20,3 +20,15 @@ export interface CARequirements {
     validity_duration?: number;         // Validity duration
     validity_unit?: ValidityUnit;       // Validity unit (hours, days, months, years)
 }
+
+export enum DataFormat {
+    DER = 'der',
+    PEM = 'pem'
+}
+
+export interface ImportCARequest {
+    cert: string;
+    key: string;
+    crl?: string;
+    format: DataFormat;
+}

--- a/frontend/src/types/CertificateRequirements.ts
+++ b/frontend/src/types/CertificateRequirements.ts
@@ -1,6 +1,7 @@
 import {CertificateRenewMethod, type CertificateType} from "@/types/Certificate.ts";
 import {ValidityUnit} from "@/types/ValidityUnit.ts";
 import type {Name} from "@/types/Name.ts";
+import type {DataFormat} from "@/types/CA.ts";
 
 export interface CertificateRequirements {
     cert_name: Name;
@@ -14,4 +15,14 @@ export interface CertificateRequirements {
     usage_limit: string[];
     renew_method: CertificateRenewMethod;
     ca_id?: number;
+}
+
+export interface ImportUserCertificateRequest {
+    p12: string;
+    password: string;
+    user_id: number;
+    ca_id: number;
+    renew_method: CertificateRenewMethod;
+    cert_type: CertificateType;
+    format: DataFormat;
 }


### PR DESCRIPTION
Introduce functionality to import Certificate Authorities (CAs) and user certificates, including handling PEM and DER formats. Update frontend UI with new modal dialogs for certificate import. Extend backend with API endpoints and supporting logic for CA and user certificate import processes.

Fixes #193