### PR TITLE
backend:helper: Add trim to secret reading

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -61,7 +61,7 @@ impl VaulTLSDB {
         let db_secret_result = get_secret("VAULTLS_DB_SECRET");
         manager = if db_encrypted {
             debug!("Using encrypted database");
-            if let Ok(ref db_secret_result) = db_secret_result {
+            if let Some(ref db_secret_result) = db_secret_result {
                 let db_secret = db_secret_result.clone();
                 manager.with_init(move |conn| {
                     conn.pragma_update(None, "key", db_secret.clone())?;

--- a/backend/src/helper.rs
+++ b/backend/src/helper.rs
@@ -12,18 +12,16 @@ where
 }
 
 /// Get secret
-pub fn get_secret(name: &str) -> anyhow::Result<String> {
+pub fn get_secret(name: &str) -> Option<String> {
+    let mut path = "/run/secrets/".to_string() + name;
     if let Ok(env_var) = env::var(name) {
-        Ok(if Path::new(&env_var).exists() {
-            fs::read_to_string(env_var)
-                .unwrap_or_default()
-                .trim()
-                .to_string()
-        } else {
-            env_var
-        })
-    } else {
-        Ok(fs::read_to_string("/run/secrets/".to_string() + name)?)
+        if !Path::new(&env_var).exists() {
+            return Some(env_var)
+        }
+        path = env_var;
     }
 
+    fs::read_to_string(path)
+        .map(|secret| secret.trim().to_string())
+        .ok()
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -75,7 +75,7 @@ pub async fn create_rocket() -> Rocket<Build> {
     let db_initialized = db_path.exists();
     let mut encrypted = settings.get_db_encrypted();
 
-    if !encrypted && let Ok(db_secret) = get_secret("VAULTLS_DB_SECRET") {
+    if !encrypted && let Some(db_secret) = get_secret("VAULTLS_DB_SECRET") {
         if db_initialized {
             VaulTLSDB::migrate_to_encrypted(&db_secret).expect("Failed to migrate database to encrypted");
         }
@@ -94,7 +94,7 @@ pub async fn create_rocket() -> Rocket<Build> {
     }
     info!("Database initialized");
 
-    if let Ok(email) = env::var("VAULTLS_ACCOUNT_EMAIL") && let Ok(password) = get_secret("VAULTLS_ACCOUNT_PASSWORD") {
+    if let Ok(email) = env::var("VAULTLS_ACCOUNT_EMAIL") && let Some(password) = get_secret("VAULTLS_ACCOUNT_PASSWORD") {
         info!("Setting password for user {} and exiting", email);
         let user = db.get_user_by_email(email.clone()).await.expect("Failed to find user");
         let password_hash = Password::new_double_hash(&password).expect("Failed to hash password");

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -2,6 +2,7 @@ use std::{env, fs};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::Arc;
+use anyhow::anyhow;
 use derive_deref::Deref;
 use openssl::base64;
 use parking_lot::RwLock;
@@ -229,7 +230,7 @@ impl Mail {
             let port = env::var("VAULTLS_MAIL_PORT")?;
             let encryption = env::var("VAULTLS_MAIL_ENCRYPTION").unwrap_or_default().into();
             let username = env::var("VAULTLS_MAIL_USERNAME").ok();
-            let password = get_secret("VAULTLS_OIDC_SECRET_PASSWORD").ok();
+            let password = get_secret("VAULTLS_OIDC_SECRET_PASSWORD");
             let from = env::var("VAULTLS_MAIL_FROM").unwrap_or_default();
 
             Ok(Mail{
@@ -280,7 +281,7 @@ impl OIDC {
     fn load_from_env(&mut self) {
         let get_env = || -> anyhow::Result<OIDC> {
             let id = env::var("VAULTLS_OIDC_ID")?;
-            let secret = get_secret("VAULTLS_OIDC_SECRET")?;
+            let secret = get_secret("VAULTLS_OIDC_SECRET").ok_or(anyhow!("No OIDC Secret specified"))?;
             let auth_url = env::var("VAULTLS_OIDC_AUTH_URL")?;
             let callback_url = env::var("VAULTLS_OIDC_CALLBACK_URL")?;
             Ok(OIDC{ id, secret, auth_url, callback_url })


### PR DESCRIPTION
If no env variable was defined to specify secret location, we use a different code path without trimming secrets file.

Unify code paths so no matter where we read the secret file from, we always trim the file.

Fixes #216