### PR TITLE
backend: tls: Start migration openssl to rcgen

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -13,7 +13,7 @@ use crate::auth::password_auth::Password;
 use crate::auth::session_auth::{generate_token, invalidate_token, Authenticated, AuthenticatedPrivileged};
 use crate::certs::common::{get_password, save_ca, Certificate, CA};
 use crate::certs::ssh_cert::{create_and_save_krl, create_krl, get_ssh_pem, retrieve_krl, SSHCertificateBuilder};
-use crate::certs::tls_cert::{create_and_save_crl, create_crl, get_timestamp, get_tls_pem, parse_ca, parse_p12, retrieve_crl, save_crl, TLSCertificateBuilder};
+use crate::certs::tls_cert::{create_and_save_crl, create_crl, get_timestamp, get_tls_pem, parse_ca, parse_p12_metadata, retrieve_crl, save_crl, TLSCertificateBuilder};
 use crate::constants::VAULTLS_VERSION;
 use crate::data::api::{CallbackQuery, ChangePasswordRequest, CreateCARequest, CreateUserCertificateRequest, CreateUserRequest, DownloadResponse, ImportCARequest, ImportUserCertificateRequest, IsSetupResponse, LoginRequest, SetupRequest};
 use crate::data::enums::{CAType, CertificateType, DataFormat, PasswordRule, TimespanUnit, UserRole};
@@ -391,7 +391,7 @@ pub(crate) async fn import_user_certificate(
         DataFormat::PEM => payload.p12.as_bytes().to_vec(),
         DataFormat::DER => BASE64_STANDARD.decode(&payload.p12).map_err(|e| ApiError::BadRequest(format!("Invalid base64 in p12: {}", e)))?,
     };
-    let (name, created_on, valid_until, _cert_der) = parse_p12(&p12_bytes, &payload.password)?;
+    let (name, created_on, valid_until) = parse_p12_metadata(&p12_bytes, &payload.password)?;
 
     let cert = Certificate {
         id: -1,
@@ -538,9 +538,9 @@ async fn get_appropriate_ca(state: &State<AppState>, payload: &CreateUserCertifi
 async fn ensure_ca_validity(ca: &mut CA, payload: &CreateUserCertificateRequest) -> Result<CA, ApiError> {
     let cert_validity = payload.validity_duration.unwrap_or(1);
     let cert_validity_unit = payload.validity_unit.unwrap_or(TimespanUnit::Year);
-    let cert_validity_timestamp = get_timestamp(cert_validity, cert_validity_unit)?;
+    let cert_validity_time = get_timestamp(cert_validity, cert_validity_unit);
 
-    if ca.valid_until == -1 || cert_validity_timestamp.0 <= ca.valid_until {
+    if ca.valid_until == -1 || (cert_validity_time.unix_timestamp() * 1000) <= ca.valid_until {
         return Ok(ca.clone());
     }
 

--- a/backend/src/certs/tls_cert.rs
+++ b/backend/src/certs/tls_cert.rs
@@ -1,23 +1,16 @@
-#[cfg(feature = "test-mode")]
-use std::env::temp_dir;
-use std::fs;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{cmp, fs};
+use std::borrow::Cow;
 use anyhow::anyhow;
 use anyhow::Result;
 use openssl::asn1::{Asn1Integer, Asn1Time};
 use openssl::bn::BigNum;
-use openssl::ec::{EcGroup, EcKey};
-use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
-use openssl::nid::Nid;
 use openssl::pkcs12::Pkcs12;
-use openssl::pkey::{PKey, Private};
+use openssl::pkey::PKey;
 use openssl::stack::Stack;
-use openssl::x509::{X509Name, X509NameBuilder, X509Ref, X509, X509Crl};
-use openssl::x509::extension::{AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName, SubjectKeyIdentifier};
-use openssl::x509::{X509Builder};
-use openssl::x509::X509Req;
-use rcgen::{CertificateRevocationListParams, Issuer, KeyIdMethod, KeyPair, RevocationReason, RevokedCertParams, SerialNumber};
+use openssl::x509::{X509, X509Builder, X509NameBuilder, X509Req};
+use openssl::x509::extension::{BasicConstraints as OpensslBasicConstraints, ExtendedKeyUsage as OpensslExtendedKeyUsage, SubjectAlternativeName as OpensslSubjectAlternativeName};
+use rcgen::{CertificateParams, CertificateRevocationListParams, DistinguishedName, DnType, Issuer, IsCa, KeyIdMethod, KeyPair, KeyUsagePurpose, RevocationReason, RevokedCertParams, SerialNumber, SanType, BasicConstraints};
 use rustls_pki_types::CertificateDer;
 use time::{OffsetDateTime, Duration};
 use tracing::info;
@@ -26,6 +19,11 @@ use crate::ApiError;
 use crate::constants::{CA_DIR_PATH, CA_FILE_PATTERN, CA_TLS_FILE_PATH, CRL_DIR_PATH, CRL_FILE_PATTERN};
 #[cfg(feature = "test-mode")]
 use crate::constants::{CA_DIR_PATH, CA_FILE_PATTERN, CA_TLS_FILE_PATH};
+#[cfg(feature = "test-mode")]
+use std::env::temp_dir;
+use openssl::nid::Nid;
+use rcgen::string::Ia5String;
+use x509_parser::prelude::{parse_x509_pem, CertificateRevocationList, FromDer, ParsedExtension, X509Certificate};
 use crate::data::enums::{CertData, CertificateRenewMethod, CertificateType, DataFormat, TimespanUnit};
 use crate::data::enums::CertificateType::{TLSClient, TLSServer};
 use crate::certs::common::{Certificate, CA};
@@ -33,32 +31,29 @@ use crate::data::enums::CAType::TLS;
 use crate::data::objects::Name;
 
 pub struct TLSCertificateBuilder {
-    x509: X509Builder,
-    private_key: Option<PKey<Private>>,
+    params: CertificateParams,
+    key_pair: KeyPair,
     created_on: i64,
     valid_until: Option<i64>,
     name: Option<Name>,
     pkcs12_password: String,
-    ca: Option<(i64, X509, PKey<Private>)>,
+    ca: Option<(i64, Vec<u8>, Vec<u8>)>,
     user_id: Option<i64>,
     renew_method: CertificateRenewMethod
 }
 impl TLSCertificateBuilder {
     pub fn new() -> Result<Self> {
-        let private_key = generate_private_key()?;
-        let asn1_serial = generate_serial_number()?;
-        let (created_on_unix, created_on_openssl) = get_timestamp(0, TimespanUnit::Hour)?;
+        let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)?;
+        let mut params = CertificateParams::default();
+        params.not_before = OffsetDateTime::now_utc();
+        params.serial_number = Some(SerialNumber::from(rand::random::<u64>()));
 
-        let mut x509 = X509Builder::new()?;
-        x509.set_version(2)?;
-        x509.set_serial_number(&asn1_serial)?;
-        x509.set_not_before(&created_on_openssl)?;
-        x509.set_pubkey(&private_key)?;
+        let created_on_unix = params.not_before.unix_timestamp_nanos() / 1_000_000;
 
         Ok(Self {
-            x509,
-            private_key: Some(private_key),
-            created_on: created_on_unix,
+            params,
+            key_pair,
+            created_on: created_on_unix as i64,
             valid_until: None,
             name: None,
             pkcs12_password: String::new(),
@@ -88,7 +83,7 @@ impl TLSCertificateBuilder {
 
     pub fn try_from_ca(old_ca: &CA) -> Result<CA> {
         if old_ca.ca_type != TLS {
-            return Err(anyhow!("CA is not of type SSH"));
+            return Err(anyhow!("CA is not of type TLS"));
         }
         let validity_h = ((old_ca.valid_until - old_ca.created_on) / 1000 / 60 / 60 / 24).max(14);
 
@@ -100,45 +95,37 @@ impl TLSCertificateBuilder {
     }
 
     pub fn set_name(mut self, name: Name) -> Result<Self, anyhow::Error> {
-        let common_name = create_cn(&name)?;
-        self.x509.set_subject_name(&common_name)?;
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, &name.cn);
+        if let Some(ref ou) = name.ou {
+            dn.push(DnType::OrganizationalUnitName, ou);
+        }
+        self.params.distinguished_name = dn;
         self.name = Some(name);
         Ok(self)
     }
 
     pub fn set_valid_until(mut self, duration: u64, unit: TimespanUnit) -> Result<Self, anyhow::Error> {
-        let (valid_until_unix, valid_until_openssl) = if duration != 0 {
-            get_timestamp(duration, unit)?
-        } else {
-            get_short_lifetime()?
-        };
-        self.valid_until = Some(valid_until_unix);
-        self.x509.set_not_after(&valid_until_openssl)?;
+        let valid_until_time = get_timestamp(duration, unit);
+        self.valid_until = Some(valid_until_time.unix_timestamp() * 1000);
+        self.params.not_after = valid_until_time;
         Ok(self)
     }
 
-    pub fn set_password(mut self, password: &str) -> Result<Self, anyhow::Error> {
+    pub fn set_password(mut self, password: &str) -> Result<Self> {
         self.pkcs12_password = password.to_string();
         Ok(self)
     }
 
-    pub fn set_dns_san(mut self, dns_names: &Vec<String>) -> Result<Self, anyhow::Error> {
-        let mut san_builder = SubjectAlternativeName::new();
+    pub fn set_dns_san(mut self, dns_names: &Vec<String>) -> Result<Self> {
         for dns in dns_names {
-            san_builder.dns(dns);
+            self.params.subject_alt_names.push(SanType::DnsName(Ia5String::try_from(dns.clone())?));
         }
-        let san = san_builder.build(&self.x509.x509v3_context(None, None))?;
-        self.x509.append_extension(san)?;
-
         Ok(self)
     }
 
-    pub fn set_email_san(mut self, email: &str) -> Result<Self, anyhow::Error> {
-        let san = SubjectAlternativeName::new()
-            .email(email)
-            .build(&self.x509.x509v3_context(None, None))?;
-        self.x509.append_extension(san)?;
-
+    pub fn set_email_san(mut self, email: &str) -> Result<Self> {
+        self.params.subject_alt_names.push(SanType::Rfc822Name(Ia5String::try_from(email.to_string())?));
         Ok(self)
     }
 
@@ -146,9 +133,7 @@ impl TLSCertificateBuilder {
         if ca.ca_type != TLS {
             return Err(anyhow!("CA is not of type SSH"));
         }
-        let ca_cert = X509::from_der(&ca.cert)?;
-        let ca_key = PKey::private_key_from_der(&ca.key)?;
-        self.ca = Some((ca.id, ca_cert, ca_key));
+        self.ca = Some((ca.id, ca.cert.clone(), ca.key.clone()));
         Ok(self)
     }
 
@@ -166,26 +151,13 @@ impl TLSCertificateBuilder {
         let name = self.name.ok_or(anyhow!("X509: name not set"))?;
         let valid_until = self.valid_until.ok_or(anyhow!("X509: valid_until not set"))?;
 
-        let cn = create_cn(&name)?;
-        self.x509.set_issuer_name(&cn)?;
+        self.params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        self.params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+        ];
 
-        let basic_constraints = BasicConstraints::new().critical().ca().build()?;
-        self.x509.append_extension(basic_constraints)?;
-
-        let key_usage = KeyUsage::new()
-            .key_cert_sign()
-            .crl_sign()
-            .build()?;
-        self.x509.append_extension(key_usage)?;
-
-        let subject_key_identifier = SubjectKeyIdentifier::new().build(&self.x509.x509v3_context(None, None))?;
-        self.x509.append_extension(subject_key_identifier)?;
-        let authority_key_identifier = AuthorityKeyIdentifier::new().keyid(true).build(&self.x509.x509v3_context(None, None))?;
-        self.x509.append_extension(authority_key_identifier)?;
-
-        let private_key = self.private_key.ok_or(anyhow!("X509: no private key for CA build"))?;
-        self.x509.sign(&private_key, MessageDigest::sha256())?;
-        let cert = self.x509.build();
+        let cert = self.params.self_signed(&self.key_pair)?;
 
         Ok(CA{
             id: -1,
@@ -193,27 +165,19 @@ impl TLSCertificateBuilder {
             created_on: self.created_on,
             valid_until,
             ca_type: TLS,
-            cert: cert.to_der()?,
-            key: private_key.private_key_to_der()?,
+            cert: cert.der().to_vec(),
+            key: self.key_pair.serialize_der(),
             crl_number: 0,
         })
     }
 
     pub fn build_client(mut self) -> Result<Certificate, anyhow::Error> {
-        let ext_key_usage = ExtendedKeyUsage::new()
-            .client_auth()
-            .build()?;
-        self.x509.append_extension(ext_key_usage)?;
-
+        self.params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ClientAuth];
         self.build_common(TLSClient)
     }
 
     pub fn build_server(mut self) -> Result<Certificate, anyhow::Error> {
-        let ext_key_usage = ExtendedKeyUsage::new()
-            .server_auth()
-            .build()?;
-        self.x509.append_extension(ext_key_usage)?;
-
+        self.params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ServerAuth];
         self.build_common(TLSServer)
     }
 
@@ -221,37 +185,34 @@ impl TLSCertificateBuilder {
         let name = self.name.ok_or(anyhow!("X509: name not set"))?;
         let valid_until = self.valid_until.ok_or(anyhow!("X509: valid_until not set"))?;
         let user_id = self.user_id.ok_or(anyhow!("X509: user_id not set"))?;
-        let (ca_id, ca_cert, ca_key) = self.ca.ok_or(anyhow!("X509: CA not set"))?;
-        let private_key = self.private_key.ok_or(anyhow!("X509: no private key"))?;
+        let (ca_id, ca_cert_der, ca_key_der) = self.ca.ok_or(anyhow!("X509: CA not set"))?;
 
-        let basic_constraints = BasicConstraints::new().build()?;
-        self.x509.append_extension(basic_constraints)?;
+        self.params.key_usages = vec![
+            KeyUsagePurpose::DigitalSignature,
+            KeyUsagePurpose::KeyEncipherment,
+        ];
+        self.params.is_ca = IsCa::ExplicitNoCa;
 
-        let key_usage = KeyUsage::new()
-            .digital_signature()
-            .key_encipherment()
-            .build()?;
-        self.x509.append_extension(key_usage)?;
+        let ca_key_pair = KeyPair::try_from(ca_key_der.clone())?;
+        let ca_cert_der_obj = CertificateDer::from(ca_cert_der.clone());
+        let issuer = Issuer::from_ca_cert_der(&ca_cert_der_obj, ca_key_pair)?;
 
-        self.x509.set_issuer_name(ca_cert.subject_name())?;
+        let cert = self.params.signed_by(&self.key_pair, &issuer)?;
+        let cert_der = cert.der().to_vec();
 
-        let subject_key_identifier = SubjectKeyIdentifier::new().build(&self.x509.x509v3_context(None, None))?;
-        self.x509.append_extension(subject_key_identifier)?;
-        
-        let authority_key_identifier = AuthorityKeyIdentifier::new().keyid(true).build(&self.x509.x509v3_context(Some(&ca_cert), None))?;
-        self.x509.append_extension(authority_key_identifier)?;
-
-        self.x509.sign(&ca_key, MessageDigest::sha256())?;
-        let cert = self.x509.build();
+        // PKCS#12 creation using openssl (as rcgen doesn't support it)
+        let openssl_cert = X509::from_der(&cert_der)?;
+        let openssl_ca_cert = X509::from_der(&ca_cert_der)?;
+        let openssl_pkey = PKey::private_key_from_der(&self.key_pair.serialize_der())?;
 
         let mut ca_stack = Stack::new()?;
-        ca_stack.push(ca_cert.clone())?;
+        ca_stack.push(openssl_ca_cert)?;
 
         let pkcs12 = Pkcs12::builder()
             .name(&name.cn)
             .ca(ca_stack)
-            .cert(&cert)
-            .pkey(&private_key)
+            .cert(&openssl_cert)
+            .pkey(&openssl_pkey)
             .build2(&self.pkcs12_password)?;
 
         Ok(Certificate {
@@ -287,9 +248,9 @@ pub fn issue_cert_from_csr(
     let ca_cert = X509::from_der(&ca.cert)?;
     let ca_key = PKey::private_key_from_der(&ca.key)?;
 
-    let asn1_serial = generate_serial_number()?;
-    let (_, not_before) = get_timestamp(0, TimespanUnit::Hour)?;
-    let (_, not_after) = get_timestamp(validity_days, TimespanUnit::Day)?;
+    let asn1_serial = generate_asn1_serial_number()?;
+    let (_, not_before) = get_asn1_timestamp(0, TimespanUnit::Hour)?;
+    let (_, not_after) = get_asn1_timestamp(validity_days, TimespanUnit::Day)?;
 
     let mut x509 = X509Builder::new()?;
     x509.set_version(2)?;
@@ -305,7 +266,7 @@ pub fn issue_cert_from_csr(
     x509.set_subject_name(&name_builder.build())?;
 
     if !dns_names.is_empty() {
-        let mut san_builder = SubjectAlternativeName::new();
+        let mut san_builder = OpensslSubjectAlternativeName::new();
         for dns in dns_names {
             san_builder.dns(dns);
         }
@@ -313,13 +274,13 @@ pub fn issue_cert_from_csr(
         x509.append_extension(san)?;
     }
 
-    let ext_key_usage = ExtendedKeyUsage::new().server_auth().build()?;
+    let ext_key_usage = OpensslExtendedKeyUsage::new().server_auth().build()?;
     x509.append_extension(ext_key_usage)?;
 
-    let basic_constraints = BasicConstraints::new().build()?;
+    let basic_constraints = OpensslBasicConstraints::new().build()?;
     x509.append_extension(basic_constraints)?;
 
-    let key_usage = KeyUsage::new()
+    let key_usage = openssl::x509::extension::KeyUsage::new()
         .digital_signature()
         .key_encipherment()
         .build()?;
@@ -327,14 +288,14 @@ pub fn issue_cert_from_csr(
 
     x509.set_issuer_name(ca_cert.subject_name())?;
 
-    let subject_key_identifier = SubjectKeyIdentifier::new().build(&x509.x509v3_context(None, None))?;
+    let subject_key_identifier = openssl::x509::extension::SubjectKeyIdentifier::new().build(&x509.x509v3_context(None, None))?;
     x509.append_extension(subject_key_identifier)?;
-    
-    let authority_key_identifier = AuthorityKeyIdentifier::new().keyid(true).build(&x509.x509v3_context(Some(&ca_cert), None))?;
+
+    let authority_key_identifier = openssl::x509::extension::AuthorityKeyIdentifier::new().keyid(true).build(&x509.x509v3_context(Some(&ca_cert), None))?;
     x509.append_extension(authority_key_identifier)?;
 
     x509.sign(&ca_key, MessageDigest::sha256())?;
-    
+
     let cert = x509.build();
 
     let serial_bytes = cert.serial_number().to_bn()?.to_vec();
@@ -347,34 +308,14 @@ pub fn issue_cert_from_csr(
     Ok((cert_pem, chain_pem, serial_bytes))
 }
 
-/// Generates a new private key.
-fn generate_private_key() -> Result<PKey<Private>, ErrorStack> {
-    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?;
-    let ec_key = EcKey::generate(&group)?;
-    let server_key = PKey::from_ec_key(ec_key)?;
-    Ok(server_key)
-}
-
-fn create_cn(name: &Name) -> Result<X509Name, ErrorStack> {
-    let mut name_builder = X509NameBuilder::new()?;
-    name_builder.append_entry_by_text("CN", &name.cn)?;
-    if let Some(ref ou) = name.ou {
-        name_builder.append_entry_by_text("OU", ou)?;
-    }
-    let name = name_builder.build();
-    Ok(name)
-}
-
-/// Generates a random serial number.
-fn generate_serial_number() -> Result<Asn1Integer, ErrorStack> {
+fn generate_asn1_serial_number() -> Result<Asn1Integer> {
     let mut big_serial = BigNum::new()?;
     big_serial.rand(64, openssl::bn::MsbOption::MAYBE_ZERO, false)?;
     let asn1_serial = big_serial.to_asn1_integer()?;
     Ok(asn1_serial)
 }
 
-/// Returns the current UNIX timestamp in milliseconds and an OpenSSL Asn1Time object.
-pub(crate) fn get_timestamp(duration: u64, unit: TimespanUnit) -> Result<(i64, Asn1Time), ErrorStack> {
+fn get_asn1_timestamp(duration: u64, unit: TimespanUnit) -> Result<(i64, Asn1Time)> {
     let duration_per_unit_h = match unit {
         TimespanUnit::Year => 365*24,
         TimespanUnit::Month => 30*24,
@@ -382,36 +323,42 @@ pub(crate) fn get_timestamp(duration: u64, unit: TimespanUnit) -> Result<(i64, A
         TimespanUnit::Hour => 1,
     };
     let duration_s = 60 * 60 * duration * duration_per_unit_h;
-    let time = SystemTime::now() + std::time::Duration::from_secs(duration_s);
-    let time_unix_ms = time.duration_since(UNIX_EPOCH).unwrap().as_millis() as i64;
+    let time = std::time::SystemTime::now() + std::time::Duration::from_secs(duration_s);
+    let time_unix_ms = time.duration_since(std::time::UNIX_EPOCH)?.as_millis() as i64;
     let time_openssl = Asn1Time::from_unix(time_unix_ms / 1000)?;
 
     Ok((time_unix_ms, time_openssl))
 }
 
-/// For E2E testing generate a short lifetime certificate.
-fn get_short_lifetime() -> Result<(i64, Asn1Time), ErrorStack> {
-    let time = SystemTime::now() + std::time::Duration::from_secs(60 * 60 * 24);
-    let time_unix = time.duration_since(UNIX_EPOCH).unwrap().as_millis() as i64;
-    let time_openssl = Asn1Time::days_from_now(1)?;
-
-    Ok((time_unix, time_openssl))
+pub(crate) fn get_timestamp(duration: u64, unit: TimespanUnit) -> OffsetDateTime {
+    let duration_per_unit_h = match unit {
+        TimespanUnit::Year => 365*24,
+        TimespanUnit::Month => 30*24,
+        TimespanUnit::Day => 24,
+        TimespanUnit::Hour => 1,
+    };
+    let duration_s = cmp::min(duration * duration_per_unit_h, 1) * 60 * 60;
+    OffsetDateTime::now_utc() + Duration::seconds(duration_s as i64)
 }
 
 /// Convert a CA certificate to PEM format.
-pub(crate) fn get_tls_pem(ca: &CA) -> Result<Vec<u8>, ErrorStack> {
+pub(crate) fn get_tls_pem(ca: &CA) -> Result<Vec<u8>> {
     let cert = X509::from_der(&ca.cert)?;
-    cert.to_pem()
+    Ok(cert.to_pem()?)
 }
 
 pub(crate) fn extract_pem_serial_number(pem: &[u8]) -> Result<Vec<u8>> {
-    let x509 = X509::from_pem(pem)?;
-    Ok(x509.serial_number().to_bn()?.to_vec())
+    let pem = parse_x509_pem(pem)
+        .map_err(|e| anyhow!("Failed to parse PEM: {}", e))?;
+    let (_, cert) = X509Certificate::from_der(&pem.1.contents)
+        .map_err(|e| anyhow!("Failed to parse DER: {}", e))?;
+    Ok(cert.tbs_certificate.serial.to_bytes_be())
 }
 
 pub(crate) fn extract_pkcs12_serial_number(pkcs12: &[u8], password: &str) -> Result<Vec<u8>> {
     let encrypted_p12 = Pkcs12::from_der(pkcs12)?;
-    let Some(inner) = encrypted_p12.parse2(password)?.cert else {
+    let parsed = encrypted_p12.parse2(password)?;
+    let Some(inner) = parsed.cert else {
         return Err(anyhow!("No certificate found in PKCS#12"));
     };
     Ok(inner.serial_number().to_bn()?.to_vec())
@@ -435,24 +382,28 @@ pub(crate) fn create_and_save_crl(ca: &mut CA, revoked_certs: Vec<(Vec<u8>, i64)
     save_crl(crl_der, ca.id)
 }
 
-fn extract_ski(cert: &X509Ref) -> Result<Vec<u8>, ErrorStack> {
-    let ext = cert.subject_key_id()
-        .ok_or_else(ErrorStack::get)?;
-    Ok(ext.as_slice().to_vec())
+fn extract_ski(cert: &X509Certificate) -> Result<Vec<u8>> {
+    cert.extensions()
+        .iter()
+        .find_map(|ext| match ext.parsed_extension() {
+            ParsedExtension::SubjectKeyIdentifier(ski) => Some(ski.0.to_vec()),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow!("No SKI extension found"))
 }
 
 pub fn create_crl(ca: &mut CA, revoked_certs: Vec<(Vec<u8>, i64)>, crl_next_update_hours: i64) -> Result<Vec<u8>> {
     let ca_key_pair = KeyPair::try_from(ca.key.clone())?;
-    let cert_der = CertificateDer::from(ca.cert.clone());
-    let issuer = Issuer::from_ca_cert_der(&cert_der, ca_key_pair)?;
+    let issuer = Issuer::from_ca_cert_der(&ca.cert.clone().into(), ca_key_pair)?;
 
     let now = OffsetDateTime::now_utc();
     let next_update = now + Duration::hours(crl_next_update_hours);
     ca.crl_number += 1;
     let crl_number = ca.crl_number;
 
-    let ca_cert = X509::from_der(&ca.cert)?;
-    let ski = extract_ski(&ca_cert)?;
+    let (_, cert) = X509Certificate::from_der(&ca.cert)
+        .map_err(|e| anyhow!("Failed to parse certificate for SKI: {}", e))?;
+    let ski = extract_ski(&cert)?;
 
     let revoked_params = revoked_certs.into_iter().map(|(serial, revoked_at)| {
         RevokedCertParams {
@@ -526,29 +477,33 @@ pub(crate) fn get_dns_names(cert: &Certificate) -> Result<Vec<String>, anyhow::E
 }
 
 pub fn parse_ca(cert_bytes: &[u8], key_bytes: &[u8], data_format: DataFormat, crl_number: i64) -> Result<CA> {
-    let cert = match data_format {
-        DataFormat::DER => X509::from_der(cert_bytes)?,
-        DataFormat::PEM => X509::from_pem(cert_bytes)?
+    use x509_parser::prelude::FromDer;
+    let cert_der = match data_format {
+        DataFormat::DER => cert_bytes.to_vec(),
+        DataFormat::PEM => {
+            let pem = parse_x509_pem(cert_bytes)
+                .map_err(|e| anyhow!("Failed to parse CA PEM: {}", e))?;
+            pem.1.contents
+        }
     };
 
-    let key = match data_format {
-        DataFormat::DER => PKey::private_key_from_der(key_bytes)?,
-        DataFormat::PEM => PKey::private_key_from_pem(key_bytes)?
-    };
+    let (_, cert) = X509Certificate::from_der(&cert_der)
+        .map_err(|e| anyhow!("Failed to parse CA DER: {}", e))?;
 
-    let subject = cert.subject_name();
-    let cn = subject.entries_by_nid(Nid::COMMONNAME)
+    let subject = &cert.tbs_certificate.subject;
+    let cn = subject.iter_common_name()
         .next()
+        .and_then(|attr| attr.as_str().ok())
         .ok_or_else(|| anyhow!("No CN in CA certificate"))?
-        .data()
-        .to_string()?;
+        .to_string();
 
-    let ou = subject.entries_by_nid(Nid::ORGANIZATIONALUNITNAME)
+    let ou = subject.iter_organizational_unit()
         .next()
-        .and_then(|e| e.data().to_string().ok());
+        .and_then(|attr| attr.as_str().ok())
+        .map(|s| s.to_string());
     
-    let created_on_unix = asn1_time_to_unix(cert.not_before())?;
-    let valid_until_unix = asn1_time_to_unix(cert.not_after())?;
+    let created_on_unix = cert.tbs_certificate.validity.not_before.timestamp() * 1000;
+    let valid_until_unix = cert.tbs_certificate.validity.not_after.timestamp() * 1000;
 
     Ok(CA {
         id: -1,
@@ -556,13 +511,13 @@ pub fn parse_ca(cert_bytes: &[u8], key_bytes: &[u8], data_format: DataFormat, cr
         created_on: created_on_unix,
         valid_until: valid_until_unix,
         ca_type: TLS,
-        cert: cert.to_der()?,
-        key: key.private_key_to_der()?,
+        cert: cert_der,
+        key: key_bytes.to_vec(),
         crl_number,
     })
 }
 
-pub fn parse_p12(p12_bytes: &[u8], password: &str) -> Result<(Name, i64, i64, Vec<u8>)> {
+pub fn parse_p12_metadata(p12_bytes: &[u8], password: &str) -> Result<(Name, i64, i64)> {
     let p12 = Pkcs12::from_der(p12_bytes)?;
     let parsed = p12.parse2(password)?;
     let cert = parsed.cert.ok_or_else(|| anyhow!("No certificate in PKCS#12"))?;
@@ -581,34 +536,34 @@ pub fn parse_p12(p12_bytes: &[u8], password: &str) -> Result<(Name, i64, i64, Ve
     let created_on_unix = asn1_time_to_unix(cert.not_before())?;
     let valid_until_unix = asn1_time_to_unix(cert.not_after())?;
 
-    Ok((Name { cn, ou }, created_on_unix, valid_until_unix, cert.to_der()?))
+    Ok((Name { cn, ou }, created_on_unix, valid_until_unix))
 }
 
 pub fn extract_crl_number(crl_bytes: &[u8], format: DataFormat) -> Result<i64> {
     let crl_der = match format {
-        DataFormat::DER => crl_bytes.to_vec(),
+        DataFormat::DER => Cow::Borrowed(crl_bytes),
         DataFormat::PEM => {
-            let crl = X509Crl::from_pem(crl_bytes)?;
-            crl.to_der()?
+            let (_, pem) = parse_x509_pem(crl_bytes)
+                .map_err(|e| anyhow!("Failed to parse CRL PEM: {e}"))?;
+            Cow::Owned(pem.contents)
         }
     };
 
-    use x509_parser::prelude::FromDer;
-    let (_, crl) = x509_parser::revocation_list::CertificateRevocationList::from_der(&crl_der)
+    let (_, crl) = CertificateRevocationList::from_der(&crl_der)
         .map_err(|e| anyhow!("Failed to parse CRL with x509-parser: {}", e))?;
-    
-    for ext in crl.extensions() {
-        if let x509_parser::extensions::ParsedExtension::CRLNumber(num) = ext.parsed_extension() {
-            let crl_number = num.to_string().parse::<i64>()?;
-            return Ok(crl_number);
-        }
-    }
 
-    Err(anyhow!("No CRL number extension in CRL"))
+    Ok(crl.extensions()
+        .iter()
+        .find_map(|ext| match ext.parsed_extension() {
+            ParsedExtension::CRLNumber(num) => Some(num),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow!("No CRL number extension found in CRL"))?
+        .to_string()
+        .parse::<i64>()?)
 }
 
 fn asn1_time_to_unix(time: &openssl::asn1::Asn1TimeRef) -> Result<i64> {
-    // We can't directly convert to UNIX, need to compare with Epoch
     let epoch = Asn1Time::from_unix(0)?;
     let diff = epoch.diff(time)?;
     Ok((diff.days as i64 * 24 * 3600 + diff.secs as i64) * 1000)

--- a/backend/src/certs/tls_cert.rs
+++ b/backend/src/certs/tls_cert.rs
@@ -337,7 +337,7 @@ pub(crate) fn get_timestamp(duration: u64, unit: TimespanUnit) -> OffsetDateTime
         TimespanUnit::Day => 24,
         TimespanUnit::Hour => 1,
     };
-    let duration_s = cmp::min(duration * duration_per_unit_h, 1) * 60 * 60;
+    let duration_s = cmp::max(duration * duration_per_unit_h, 1) * 60 * 60;
     OffsetDateTime::now_utc() + Duration::seconds(duration_s as i64)
 }
 

--- a/backend/tests/api/api_test_functionality.rs
+++ b/backend/tests/api/api_test_functionality.rs
@@ -414,7 +414,7 @@ async fn test_create_certificate_with_short_lived_ca() -> Result<()> {
 
     let cert_req = CreateUserCertificateRequest {
         cert_name: TEST_CLIENT_CERT_NAME.into(),
-        validity_duration: Some(2),
+        validity_duration: Some(3),
         validity_unit: Some(TimespanUnit::Year),
         user_id: 1,
         notify_user: None,


### PR DESCRIPTION
Currently the TLS backend uses a mix of rcgen, x509-parser and openssl. The problem is that all three libs offer something unique. Ideally I want to minimize the amount VaulTLS has to rely on openssl C-bindings library for easier compile and a more streamlined approach. It should give us also more control over certificate creation such as specifying extensions.

Rework TLS creation logic to use mostly rcgen.